### PR TITLE
Remove trailing slash from log dir in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ There are different customizations available, in fact, it is possible to:
 
 ### Change default handler target folder
 
-By default, target folder for default handler is `WP_CONTENT . '/wonolog/'`. This folder can be changed in two ways:
+By default, target folder for default handler is `WP_CONTENT . '/wonolog'`. This folder can be changed in two ways:
 
  - via the environment variable **`'WONOLOG_HANDLER_FILE_DIR'`**
  - via the filter **`'wonolog.default-handler-folder'`**


### PR DESCRIPTION
the code actually defines WONOLOG_HANDLER_FILE_DIR default value without
trailing slash. It also seems that the code expect this env var to be
without trailing slash.
