### PR TITLE
Fix monolog version constraint on ^1.21.0 (stick to semantic versioning)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.6",
-    "monolog/monolog": "@stable"
+    "monolog/monolog": "^1.21.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7.21",


### PR DESCRIPTION
Hello there,

As mentioned in https://github.com/inpsyde/Wonolog/issues/43, monolog `2.0.0` includes multiple backwards compatibility breaks (see https://github.com/Seldaek/monolog/releases/tag/2.0.0)

As long as wonolog isn't fully tested and fixed to work correctly with monolog 2.x, we should stick to semantic versioning and only allow updates that does not include backwards compatibility breaks.

This PR changes the version constraint of monolog to `^1.21.0` (equivalent for `>=1.21.0 <2.0.0`). With this constraint, installing / updating the project today will end up with having the latest 1.x version of monolog installed, `1.25.1`, which is, I think, what we want.

Note :
- I picked `1.21.0` as a minimal version because it was the latest monolog release when wonolog was first published, but we could probably have `^1.0.0` if we want a wider compatibility with other packages having monolog as a dependency (not tested).

Bests regards,
Pierre