### PR TITLE
Do not log silenced PHP errors

### DIFF
--- a/docs/03-a-deeper-look-at-wonolog.md
+++ b/docs/03-a-deeper-look-at-wonolog.md
@@ -47,7 +47,7 @@ Please keep in mind that such customization **must be done in an MU plugin**, be
 
 ## Wonolog PHP Error Handler
 
-As mentioned before, by default, Wonolog logs all kinds of PHP errors.
+As mentioned before, by default, Wonolog logs all kinds of PHP errors. It does not log silenced PHP errors.
 
 This is possible because Wonolog registers custom error and exception handlers.
 
@@ -76,6 +76,10 @@ The **log channel** used for these events is `Channels::PHP_ERROR`, and the **lo
 
 Refer to [Wonolog Customization](05-wonolog-customization.md) to learn how to customize or even disable this PHP error handler.
 
+If you want to log also silenced PHP errors you can do so with a filter:
+```
+add_filter('wonolog.report-silenced-errors', '__return_true');
+```
 
 ## Default Handler Minimum Log Level
 

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -77,8 +77,7 @@ class PhpErrorController {
 			$num,
 			$str,
 			$file,
-			$line,
-			$context
+			$line
 		);
 
 		if ( $level === NULL || ! $report_silenced ) {

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -73,7 +73,7 @@ class PhpErrorController {
 
 		$report_silenced = apply_filters(
 			'wonolog.report-silenced-errors',
-			error_reporting() >= 0,
+			error_reporting() !== 0,
 			$num,
 			$str,
 			$file,

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -67,6 +67,22 @@ class PhpErrorController {
 	 */
 	public function on_error( $num, $str, $file, $line, $context = NULL ) {
 
+		$level = isset( self::$errors_level_map[ $num ] )
+			? self::$errors_level_map[ $num ]
+			: NULL;
+
+		$report_silenced = apply_filters(
+			'wonolog.report-silenced-errors',
+			error_reporting() >= 0,
+			$errorMessage,
+			$errorFile,
+			$errorLine
+		);
+
+		if ( $level === NULL || ! $report_silenced ) {
+			return FALSE;
+		}
+
 		$log_context = [];
 		if ( $context ) {
 			$skip_keys   = array_merge( array_keys( $GLOBALS ), self::$super_globals_keys );
@@ -80,7 +96,7 @@ class PhpErrorController {
 		// Log the PHP error.
 		do_action(
 			\Inpsyde\Wonolog\LOG,
-			new Log( $str, self::$errors_level_map[ $num ], Channels::PHP_ERROR, $log_context )
+			new Log( $str, $level, Channels::PHP_ERROR, $log_context )
 		);
 
 		return FALSE;

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -74,9 +74,11 @@ class PhpErrorController {
 		$report_silenced = apply_filters(
 			'wonolog.report-silenced-errors',
 			error_reporting() >= 0,
-			$errorMessage,
-			$errorFile,
-			$errorLine
+			$num,
+			$str,
+			$file,
+			$line,
+			$context
 		);
 
 		if ( $level === NULL || ! $report_silenced ) {


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #50 .

#### What's Included in This Pull Request

* Stops logging errors which are silenced (e.g. `@fopen('file-does-not-exist')`).
* Introduces a filter to log silenced errors again.
