### PR TITLE
Micro typo in anchor link

### DIFF
--- a/docs/03-a-deeper-look-at-wonolog.md
+++ b/docs/03-a-deeper-look-at-wonolog.md
@@ -5,7 +5,7 @@
 - [Wonolog Channels](#wonolog-channels)
 - [Wonolog PHP Error Handler](#wonolog-php-error-handler)
 - [Default Handler Minimum Log Level](#default-handler-minimum-log-level)
-- [The "Logging Dilemma"](#the-logging-dilemma")
+- [The "Logging Dilemma"](#the-logging-dilemma)
 
 
 ## Wonolog Channels


### PR DESCRIPTION
Corrected the anchor link to ["The Logging Dilemma"](https://github.com/inpsyde/Wonolog/blob/9c8cdf64c163ec67e005c4a8f25e7c1a38da9eb6/docs/03-a-deeper-look-at-wonolog.md#table-of-contents)