### PR TITLE
Add Query Monitor handler.

### DIFF
--- a/src/Handler/QueryMonitorHandler.php
+++ b/src/Handler/QueryMonitorHandler.php
@@ -1,0 +1,55 @@
+<?php # -*- coding: utf-8 -*-
+/*
+ * This file is part of the Wonolog package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Inpsyde\Wonolog\Handler;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Psr\Log\LogLevel;
+
+/**
+ * Class QueryMonitorHandler.
+ *
+ * @package BoxUk\Plugins\Base
+ */
+class QueryMonitorHandler extends AbstractProcessingHandler {
+	private static $level_map = array(
+		LogLevel::DEBUG => 'qm/debug',
+		LogLevel::INFO => 'qm/info',
+		LogLevel::NOTICE => 'qm/notice',
+		LogLevel::WARNING => 'qm/warning',
+		LogLevel::ERROR => 'qm/error',
+		LogLevel::CRITICAL => 'qm/critical',
+		LogLevel::ALERT => 'qm/alert',
+		LogLevel::EMERGENCY => 'qm/emergency',
+	);
+
+	/**
+	 * Write the log to the Query Monitor log.
+	 *
+	 * @param array $record The record to write.
+	 *
+	 * @return void
+	 */
+	protected function write( array $record ) {
+		$level = $this->map_level( $record['level_name'] );
+		do_action( $level, $record['message'], $record['context'] );
+	}
+
+	/**
+	 * Map the log level to the Query Monitor log level.
+	 *
+	 * @param string $level_name Level name to map.
+	 *
+	 * @return string
+	 */
+	private function map_level( $level_name ) {
+		return isset( self::$level_map[ strtolower( $level_name ) ] ) ? self::$level_map[ strtolower( $level_name ) ] : 'qm/debug';
+	}
+}

--- a/tests/src/Unit/Handler/QueryMonitorHandlerTest.php
+++ b/tests/src/Unit/Handler/QueryMonitorHandlerTest.php
@@ -40,17 +40,57 @@ class QueryMonitorHandlerTest extends TestCase {
         $handler->handle( $this->get_record( Logger::DEBUG, 'This is a test', [ 'foo' => 'bar' ] ) );
     }
 
+    public function test_the_handler_does_not_log_if_message_empty() {
+        $handler = new QueryMonitorHandler();
+        $handler->handle( $this->get_record( Logger::DEBUG, '', [ 'foo' => 'bar' ] ) );
+
+        self::assertFalse( (bool) did_action( 'qm/debug' ) );
+    }
+
+    public function test_the_handler_defaults_to_debug_if_no_level_name_supplied_in_record() {
+        $record = $this->get_record( Logger::DEBUG, 'Test', [ 'foo' => 'bar' ] );
+        $handler = new QueryMonitorHandler();
+
+        // Remove level details.
+        unset( $record['level_name'] );
+        $handler->handle( $record );
+
+        self::assertTrue( (bool) did_action( 'qm/debug' ) );
+    }
+
+    public function test_the_handler_defaults_to_debug_if_level_name_is_null() {
+        $record = $this->get_record( Logger::DEBUG, 'Test', [ 'foo' => 'bar' ] );
+        $handler = new QueryMonitorHandler();
+
+        // Set level to null.
+        $record['level_name'] = null;
+        $handler->handle( $record );
+
+        self::assertTrue( (bool) did_action( 'qm/debug' ) );
+    }
+
+    public function test_the_handler_defaults_to_debug_if_level_name_is_invalid() {
+        $record = $this->get_record( Logger::DEBUG, 'Test', [ 'foo' => 'bar' ] );
+        $handler = new QueryMonitorHandler();
+
+        // Set level to invalid value.
+        $record['level_name'] = 'invalid';
+        $handler->handle( $record );
+
+        self::assertTrue( (bool) did_action( 'qm/debug' ) );
+    }
+
     public function get_levels() {
-        return array(
-            'Debug level' => array( Logger::DEBUG, 'qm/debug' ),
-            'Info level' => array( Logger::INFO, 'qm/info' ),
-            'Notice level' => array( Logger::NOTICE, 'qm/notice' ),
-            'Warning level' => array( Logger::WARNING, 'qm/warning' ),
-            'Error level' => array( Logger::ERROR, 'qm/error' ),
-            'Critical level' => array( Logger::CRITICAL, 'qm/critical' ),
-            'Alert level' => array( Logger::ALERT, 'qm/alert' ),
-            'Emergency level' => array( Logger::EMERGENCY, 'qm/emergency' ),
-        );
+        return [
+            'Debug level' => [ Logger::DEBUG, 'qm/debug' ],
+            'Info level' => [ Logger::INFO, 'qm/info' ],
+            'Notice level' => [ Logger::NOTICE, 'qm/notice' ],
+            'Warning level' => [ Logger::WARNING, 'qm/warning' ],
+            'Error level' => [ Logger::ERROR, 'qm/error' ],
+            'Critical level' => [ Logger::CRITICAL, 'qm/critical' ],
+            'Alert level' => [ Logger::ALERT, 'qm/alert' ],
+            'Emergency level' => [ Logger::EMERGENCY, 'qm/emergency' ],
+        ];
     }
 
     /**
@@ -61,13 +101,13 @@ class QueryMonitorHandlerTest extends TestCase {
      * @return array
      */
     protected function get_record( $level = Logger::WARNING, $message = 'test', $context = [] ) {
-        return array(
+        return [
             'message' => (string) $message,
             'context' => $context,
             'level' => $level,
             'level_name' => Logger::getLevelName( $level ),
             'channel' => 'test',
-            'extra' => array(),
-        );
+            'extra' => [],
+        ];
     }
 }

--- a/tests/src/Unit/Handler/QueryMonitorHandlerTest.php
+++ b/tests/src/Unit/Handler/QueryMonitorHandlerTest.php
@@ -1,0 +1,73 @@
+<?php # -*- coding: utf-8 -*-
+/*
+ * This file is part of the Wonolog package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Inpsyde\Wonolog\Tests\Unit\Handler;
+
+use Inpsyde\Wonolog\Handler\QueryMonitorHandler;
+use Inpsyde\Wonolog\Tests\TestCase;
+use Monolog\Logger;
+
+use function Brain\Monkey\Actions\expectDone;
+
+/**
+ * @package wonolog\tests
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+class QueryMonitorHandlerTest extends TestCase {
+    /**
+     * @dataProvider get_levels
+     */
+    public function test_the_handler_raises_the_appropriate_action( $log_level, $expected_qm_action ) {
+        $handler = new QueryMonitorHandler();
+        $handler->handle( $this->get_record( $log_level ) );
+
+        self::assertTrue( (bool) did_action( $expected_qm_action ) );
+    }
+
+    public function test_the_handler_adds_the_message_to_the_log() {
+        expectDone( 'qm/debug' )
+            ->once()
+            ->with( 'This is a test', [ 'foo' => 'bar' ] );
+
+        $handler = new QueryMonitorHandler();
+        $handler->handle( $this->get_record( Logger::DEBUG, 'This is a test', [ 'foo' => 'bar' ] ) );
+    }
+
+    public function get_levels() {
+        return array(
+            'Debug level' => array( Logger::DEBUG, 'qm/debug' ),
+            'Info level' => array( Logger::INFO, 'qm/info' ),
+            'Notice level' => array( Logger::NOTICE, 'qm/notice' ),
+            'Warning level' => array( Logger::WARNING, 'qm/warning' ),
+            'Error level' => array( Logger::ERROR, 'qm/error' ),
+            'Critical level' => array( Logger::CRITICAL, 'qm/critical' ),
+            'Alert level' => array( Logger::ALERT, 'qm/alert' ),
+            'Emergency level' => array( Logger::EMERGENCY, 'qm/emergency' ),
+        );
+    }
+
+    /**
+     * @param int    $level Level to log.
+     * @param string $message Message to log.
+     * @param array   $context Context to log.
+     *
+     * @return array
+     */
+    protected function get_record( $level = Logger::WARNING, $message = 'test', $context = [] ) {
+        return array(
+            'message' => (string) $message,
+            'context' => $context,
+            'level' => $level,
+            'level_name' => Logger::getLevelName( $level ),
+            'channel' => 'test',
+            'extra' => array(),
+        );
+    }
+}


### PR DESCRIPTION
As Query Monitor is so ubiquitous througout WordPress development and it has it's
own [neat logging capability](https://querymonitor.com/docs/logging-variables/) it's useful to be able to configure Wonolog to write to the query monitor log.

This enables us to use the same logging code across environments and log
to query monitor on the environments we wish. For example, we log to
disk for local dev, QM on QA and Staging and New Relic in production.

Handlers should generally be added in userland, however as mentioned
with Query Monitor so ubiquitous it may be a nice offering to offer as
part of Wonolog.

<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->
