### PR TITLE
PHP 8+ Support for v1 Branch

### DIFF
--- a/src/Data/Log.php
+++ b/src/Data/Log.php
@@ -30,9 +30,9 @@ final class Log implements LogDataInterface {
 	 * @var array
 	 */
 	private static $filters = [
-		self::MESSAGE => FILTER_SANITIZE_STRING,
+		self::MESSAGE => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 		self::LEVEL   => FILTER_SANITIZE_NUMBER_INT,
-		self::CHANNEL => FILTER_SANITIZE_STRING,
+		self::CHANNEL => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 		self::CONTEXT => [ 'filter' => FILTER_UNSAFE_RAW, 'flags' => FILTER_REQUIRE_ARRAY ],
 	];
 

--- a/src/Handler/HandlersRegistry.php
+++ b/src/Handler/HandlersRegistry.php
@@ -121,6 +121,7 @@ class HandlersRegistry implements \Countable {
 	/**
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	public function count() {
 
 		return count( $this->handlers );

--- a/src/HookListener/WpDieHandlerListener.php
+++ b/src/HookListener/WpDieHandlerListener.php
@@ -52,7 +52,7 @@ final class WpDieHandlerListener implements FilterListenerInterface {
 
 		return function ( $message, $title = '', $args = [] ) use ( $handler ) {
 
-			$msg                = filter_var( $message, FILTER_SANITIZE_STRING );
+			$msg                = filter_var( $message, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			$context            = $args;
 			$context[ 'title' ] = $title;
 

--- a/src/Processor/ProcessorsRegistry.php
+++ b/src/Processor/ProcessorsRegistry.php
@@ -90,6 +90,7 @@ class ProcessorsRegistry implements \Countable {
 	/**
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	public function count() {
 
 		return count( $this->processors );


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #72.

#### What's Included in This Pull Request

This PR adds PHP 8+ support:
* Replace depreacted `FILTER_SANITIZE_STRING` filter with `FILTER_SANITIZE_FULL_SPECIAL_CHARS`.
* Add `#[\ReturnTypeWillChange]` attribute to `count` method of both registry classes.
