### PR TITLE
refactor: Update package to support php >=8 and Psr Log 2 || 3

### DIFF
--- a/.github/workflows/php-integration-tests.yml
+++ b/.github/workflows/php-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-service: [ '80', '81', '82' ]
+                php-service: [ '81', '82' ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3

--- a/.github/workflows/php-integration-tests.yml
+++ b/.github/workflows/php-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-service: [ '72', '73', '74', '80', '81', '82' ]
+                php-service: [ '80', '81', '82' ]
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -33,35 +33,20 @@ jobs:
         with:
             PHP_MATRIX: '["8.0", "8.1", "8.2"]'
 
-    coding-standards-analysis-php-80:
+    coding-standards-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+        strategy:
+            matrix:
+                php-version: ['8.0', '8.1', '8.2']
         with:
-            PHP_VERSION: '8.0'
-    coding-standards-analysis-php-81:
-        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
-        uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
-        with:
-            PHP_VERSION: '8.1'
-    coding-standards-analysis-php-82:
-        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
-        uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
-        with:
-            PHP_VERSION: '8.2'
+            PHP_VERSION: ${{ matrix.php-version }}
 
-    static-code-analysis-php-80:
+    static-code-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+        strategy:
+            matrix:
+                php-version: [ '8.0', '8.1', '8.2' ]
         with:
-            PHP_VERSION: '8.0'
-    static-code-analysis-php-81:
-        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
-        uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
-        with:
-            PHP_VERSION: '8.1'
-    static-code-analysis-php-82:
-        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
-        uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
-        with:
-            PHP_VERSION: '8.2'
-
+            PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -31,19 +31,19 @@ jobs:
         uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run lint only')) }}
         with:
-            PHP_MATRIX: '["8.0", "8.1", "8.2"]'
+            PHP_MATRIX: '["8.1", "8.2"]'
 
     coding-standards-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
         with:
-            PHP_VERSION: '8.0'
+            PHP_VERSION: '8.1'
 
     static-code-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
         strategy:
             matrix:
-                php-version: [ '8.0', '8.1', '8.2' ]
+                php-version: [ '8.1', '8.2' ]
         with:
             PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -33,9 +33,21 @@ jobs:
         with:
             PHP_MATRIX: '["8.0", "8.1", "8.2"]'
 
-    coding-standards-analysis-php:
+    coding-standards-analysis-php-80:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+        with:
+            PHP_VERSION: '8.0'
+    coding-standards-analysis-php-81:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+        with:
+            PHP_VERSION: '8.1'
+    coding-standards-analysis-php-82:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+        with:
+            PHP_VERSION: '8.2'
 
     static-code-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -36,11 +36,8 @@ jobs:
     coding-standards-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
-        strategy:
-            matrix:
-                php-version: ['8.0', '8.1', '8.2']
         with:
-            PHP_VERSION: ${{ matrix.php-version }}
+            PHP_VERSION: '8.0'
 
     static-code-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -49,6 +49,19 @@ jobs:
         with:
             PHP_VERSION: '8.2'
 
-    static-code-analysis-php:
+    static-code-analysis-php-80:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
         uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+        with:
+            PHP_VERSION: '8.0'
+    static-code-analysis-php-81:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+        with:
+            PHP_VERSION: '8.1'
+    static-code-analysis-php-82:
+        if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run Psalm only')) }}
+        uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+        with:
+            PHP_VERSION: '8.2'
+

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -31,7 +31,7 @@ jobs:
         uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run lint only')) }}
         with:
-            PHP_MATRIX: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+            PHP_MATRIX: '["8.0", "8.1", "8.2"]'
 
     coding-standards-analysis-php:
         if: ${{ (github.event_name != 'workflow_dispatch') || ((github.event.inputs.jobs == 'Run all') || (github.event.inputs.jobs == 'Run PHPCS only')) }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: [ '8.0', '8.1', '8.2' ]
+                php-versions: [ '8.1', '8.2' ]
                 dependency-versions: ['highest', 'lowest']
 
         steps:

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -26,6 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 php-versions: [ '8.0', '8.1', '8.2' ]
+                dependency-versions: ['highest', 'lowest']
 
         steps:
             - name: Checkout
@@ -44,6 +45,8 @@ jobs:
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v2
+              with:
+                dependency-versions: ${{ matrix.dependency-versions }}
 
             - name: Run unit tests
               run: composer tests:unit:${{ ((env.USE_COVERAGE == 'yes') && 'codecov') || 'no-cov' }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+                php-versions: [ '8.0', '8.1', '8.2' ]
 
         steps:
             - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # Adding a folder to put things temporarily
 temp/
 
+# IDE
+.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 
 # Docker
 .github/workflows/docker/php*/*.sh
+
+# Adding a folder to put things temporarily
+temp/
+

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.0 < 8.3",
         "psr/log": "^2.0||^3.0",
         "wecodemore/wordpress-early-hook": "^1.1.0",
         "monolog/monolog": "^2.3.5"

--- a/composer.json
+++ b/composer.json
@@ -37,22 +37,22 @@
         }
     ],
     "require": {
-        "php": ">=7.2 < 8.3",
-        "psr/log": "^1.1.4",
+        "php": ">=8.0",
+        "psr/log": "^2.0||^3.0",
         "wecodemore/wordpress-early-hook": "^1.1.0",
         "monolog/monolog": "^2.3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.33",
         "brain/monkey": "^2.6.1",
         "mockery/mockery": "^1.3.6",
         "mikey179/vfsstream": "~v1.6.11",
         "inpsyde/php-coding-standards": "^1",
-        "vimeo/psalm": "^4.30.0",
         "inpsyde/wp-stubs-versions": "dev-latest",
         "roots/wordpress-no-content": ">=6.1.1",
         "symfony/process": "^v4.4.44",
-        "globalis/wp-cli-bin": "^2.7.1"
+        "globalis/wp-cli-bin": "^2.7.1",
+        "vimeo/psalm": "^5.15",
+        "phpunit/phpunit": "^9.6"
     },
     "provide": {
         "psr/log-implementation": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "symfony/process": "^v4.4.44",
         "globalis/wp-cli-bin": "^2.7.1",
         "vimeo/psalm": "^5.15",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "fig/log-test": "^1.1"
     },
     "provide": {
         "psr/log-implementation": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0 < 8.3",
+        "php": ">=8.1 < 8.3",
         "psr/log": "^2.0||^3.0",
         "wecodemore/wordpress-early-hook": "^1.1.0",
         "monolog/monolog": "^2.3.5"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-	backupGlobals="false"
-	backupStaticAttributes="false"
-	bootstrap="tests/bootstrap.php"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-    convertDeprecationsToExceptions="true"
-	processIsolation="false"
-	stopOnFailure="false">
-
-    <extensions>
-        <extension class="Inpsyde\Wonolog\Tests\IntegrationTestsExtension"/>
-    </extensions>
-
-	<testsuites>
-		<testsuite name="unit">
-			<directory suffix="Test.php">tests/unit</directory>
-		</testsuite>
-		<testsuite name="integration">
-			<directory suffix="Test.php">tests/integration</directory>
-		</testsuite>
-	</testsuites>
-
-	<filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <extensions>
+    <extension class="Inpsyde\Wonolog\Tests\IntegrationTestsExtension"/>
+  </extensions>
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">tests/unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory suffix="Test.php">tests/integration</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Data/FailedLogin.php
+++ b/src/Data/FailedLogin.php
@@ -107,15 +107,25 @@ final class FailedLogin implements LogData
             || !isset($attempts[$userIp]['count'])
             || !isset($attempts[$userIp]['last_logged'])
         ) {
-            $attempts[$userIp] = ['count' => 0, 'last_logged' => 0];
+            /**
+             * @var array<string, array{count: int, last_logged: int}> $data
+             */
+            $data = ['count' => 0, 'last_logged' => 0];
+            $attempts[$userIp] = $data;
         }
 
         /** @psalm-suppress MixedOperand */
         $attempts[$userIp]['count']++;
-        /** @psalm-suppress PropertyTypeCoercion */
+        /** @psalm-suppress InvalidPropertyAssignmentValue */
         $this->attemptsData = $attempts;
 
+        /**
+         * Psalm warns us about count and last_logged possibly being bool to int converted
+         * We assume the value retrieved when calling get_site_transient is an integer on both
+         * @psalm-suppress RiskyCast
+         */
         $count = (int)$attempts[$userIp]['count'];
+        /** @psalm-suppress RiskyCast */
         $lastLogged = (int)$attempts[$userIp]['last_logged'];
 
         /**

--- a/src/DefaultHandler/LogsFolder.php
+++ b/src/DefaultHandler/LogsFolder.php
@@ -35,7 +35,7 @@ class LogsFolder
          * them, and package could be fully functional even if failures happen.
          * Silence looks like best option here.
          *
-         * Also for some reason __return_true seems not to be a valid argument¿?
+         * Also for some reason __return_true seems not to be a valid argument?
          * I found this related issue https://github.com/vimeo/psalm/issues/3571
          *
          * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler

--- a/src/DefaultHandler/LogsFolder.php
+++ b/src/DefaultHandler/LogsFolder.php
@@ -35,7 +35,11 @@ class LogsFolder
          * them, and package could be fully functional even if failures happen.
          * Silence looks like best option here.
          *
+         * Also for some reason __return_true seems not to be a valid argument¿?
+         * I found this related issue https://github.com/vimeo/psalm/issues/3571
+         *
          * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+         * @psalm-suppress PossiblyInvalidArgument
          */
         set_error_handler('__return_true');
 

--- a/src/HookListener/CronDebugListener.php
+++ b/src/HookListener/CronDebugListener.php
@@ -83,7 +83,7 @@ final class CronDebugListener implements ActionListener
         }
 
         $cronArray = _get_cron_array();
-        /** @psalm-suppress DocblockTypeContradiction  */
+        /** @psalm-suppress TypeDoesNotContainType,DocblockTypeContradiction  */
         if (!$cronArray || !is_array($cronArray)) {
             return;
         }

--- a/src/PsrBridge.php
+++ b/src/PsrBridge.php
@@ -72,7 +72,7 @@ class PsrBridge extends AbstractLogger
      *
      * phpcs:disable Generic.Metrics.CyclomaticComplexity
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         // phpcs:enable Generic.Metrics.CyclomaticComplexity
         $throwable = null;

--- a/tests/unit/HookListener/CronDebugListenerTest.php
+++ b/tests/unit/HookListener/CronDebugListenerTest.php
@@ -109,8 +109,8 @@ class CronDebugListenerTest extends UnitTestCase
 
         $regxp = '~^Cron action "%s" performed\. Duration: [0|1]\.[0-9]+ seconds\.$~';
 
-        static::assertRegExp(sprintf($regxp, 'wp_scheduled_delete'), $logs[0]);
-        static::assertRegExp(sprintf($regxp, 'wp_update_plugins'), $logs[1]);
-        static::assertRegExp(sprintf($regxp, 'wp_version_check'), $logs[2]);
+        static::assertMatchesRegularExpression(sprintf($regxp, 'wp_scheduled_delete'), $logs[0]);
+        static::assertMatchesRegularExpression(sprintf($regxp, 'wp_update_plugins'), $logs[1]);
+        static::assertMatchesRegularExpression(sprintf($regxp, 'wp_version_check'), $logs[2]);
     }
 }


### PR DESCRIPTION
Updating dependencies to be able to work with newer Psr/Log BREAKING CHANGE: we are dropping support for PHP 7.x and Psr/Log 1.x

<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #.

#### What's Included in This Pull Request

* Drop support for PHP 7.x
* Drop support for Psr/Log 1.x and support Psr/Log 2.x || 3.x
* Update of PHP Unit to v9 since it was required to achieve the goal
* Update of Psalm since it was required to achieve the goal
* Require the test class from the new package since the test folder was deleted from the source
* Added new strategy in the matrix of PHPUnit testing to use --prefer-lowest and resolve to psr/log v2 during the installation
* Added other PHP static analysis using with different PHP versions
* Fixed Psalm issues mostly adding new annotations since Psalm does not know about different WP versions
* Updated PHPUnit config to remove dprecation warning
* Changed the usage of assertRegexp in test to the new method as it will be deprecated in PHPUnit 10


