### PR TITLE
fix: PHPMailer namespace in MailerListener

### DIFF
--- a/src/HookListener/MailerListener.php
+++ b/src/HookListener/MailerListener.php
@@ -18,6 +18,8 @@ use Inpsyde\Wonolog\Data\Debug;
 use Inpsyde\Wonolog\Data\Log;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\LogLevel;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 
 /**
  * Try to log any error in PHPMailer.
@@ -85,8 +87,8 @@ class MailerListener implements ActionListener
     {
         $mailer = $args ? reset($args) : null;
         /** @psalm-suppress UndefinedClass */
-        if ($mailer instanceof \PHPMailer) {
-            $mailer->SMTPDebug = 2;
+        if ($mailer instanceof PHPMailer) {
+            $mailer->SMTPDebug = SMTP::DEBUG_SERVER;
             $mailer->Debugoutput = static function (string $message) use ($updater): void {
                 $updater->update(new Debug($message, Channels::HTTP));
             };


### PR DESCRIPTION
@see https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/PHPMailer/PHPMailer.php#L22
