### PR TITLE
Fix type error caused by `HttpApiListener:is_cron()` with null $url

### DIFF
--- a/src/HookListener/HttpApiListener.php
+++ b/src/HookListener/HttpApiListener.php
@@ -125,7 +125,7 @@ final class HttpApiListener implements ActionListenerInterface {
 
 		return
 			is_array( $response )
-			&& basename( parse_url( $url, PHP_URL_PATH ) ) === 'wp-cron.php';
+			&& basename((string) parse_url( $url, PHP_URL_PATH ) ) === 'wp-cron.php';
 	}
 
 	/**


### PR DESCRIPTION
If the `$response` argument passed to `HttpApiListener:is_cron()` is in fact an array and `$url` is null or something that results in `parse_url()` returning null, a `TypeError` will occur due to `basename()` only accepting strings.

#### What's Included in This Pull Request

* The return value of `parse_url()` is casted to a string.
