### PR TITLE
Test Enea

### DIFF
--- a/.github/workflows/docker/php81/Dockerfile
+++ b/.github/workflows/docker/php81/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/bin/install-composer.sh && /usr/bin/install-composer.sh && mv 
 COPY wait-for.sh /usr/bin/wait-for.sh
 RUN chmod +x /usr/bin/wait-for.sh
 
+RUN git config --global --add safe.directory /var/www/html
+
 WORKDIR /var/www/html

--- a/.github/workflows/docker/php82/Dockerfile
+++ b/.github/workflows/docker/php82/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/bin/install-composer.sh && /usr/bin/install-composer.sh && mv 
 COPY wait-for.sh /usr/bin/wait-for.sh
 RUN chmod +x /usr/bin/wait-for.sh
 
+RUN git config --global --add safe.directory /var/www/html
+
 WORKDIR /var/www/html

--- a/tests/integration/AdvancedConfigTest.php
+++ b/tests/integration/AdvancedConfigTest.php
@@ -132,7 +132,7 @@ class AdvancedConfigTest extends IntegrationTestCase
         );
 
         static::assertTrue($this->testHandler->hasDebugThatContains('Something happened.'));
-//        static::assertFalse(file_exists($this->logFile));
+        static::assertFalse(file_exists($this->logFile));
     }
 
     /**
@@ -170,7 +170,7 @@ class AdvancedConfigTest extends IntegrationTestCase
 
         static::assertFalse($this->testHandler->hasNoticeThatContains('Something happened.'));
 
-//        static::assertFalse(file_exists($this->logFile));
+        static::assertFalse(file_exists($this->logFile));
     }
 
     /**
@@ -188,7 +188,7 @@ class AdvancedConfigTest extends IntegrationTestCase
         );
 
         static::assertFalse($this->testHandler->hasNoticeThatContains('cron job'));
-//        static::assertFalse(file_exists($this->logFile));
+        static::assertFalse(file_exists($this->logFile));
     }
 
     /**

--- a/tests/src/IntegrationTestsExtension.php
+++ b/tests/src/IntegrationTestsExtension.php
@@ -207,10 +207,10 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
     private function deleteDefaultTheme(): void
     {
         $themeDir = ABSPATH . 'wp-content/themes/test-theme';
-		if (!\is_dir($themeDir)) {
-			\fwrite(STDOUT, "Test theme not found at $themeDir\n");
-			return;
-		}
+        if (!\is_dir($themeDir)) {
+            \fwrite(STDOUT, "Test theme not found at $themeDir\n");
+            return;
+        }
 
         \array_map('unlink', (array) \glob($themeDir . '/*.*'));
         \rmdir($themeDir);

--- a/tests/src/IntegrationTestsExtension.php
+++ b/tests/src/IntegrationTestsExtension.php
@@ -150,7 +150,7 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
         static::runWpCliCommand(['config', 'set', 'SAVEQUERIES', 'true']);
 
         static::resetDb();
-        $this->createDefaultTheme();
+        $this->createThemesFolder();
     }
 
     /**
@@ -159,7 +159,6 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
     public function executeAfterLastTest(): void
     {
         $this->resetWpConfig(true);
-        $this->deleteDefaultTheme();
     }
 
     /**
@@ -189,32 +188,19 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
         return true;
     }
 
-    private function createDefaultTheme(): void
+    private function createThemesFolder(): void
     {
-        $themeDir = ABSPATH . 'wp-content/themes/test-theme';
+        $themeDir = ABSPATH . 'wp-content/themes';
+		$result = true;
         if (!\is_dir($themeDir)) {
-            \mkdir($themeDir, 0755, true);
+	        $result = \mkdir($themeDir, 0755, true);
         }
 
-        \file_put_contents($themeDir . '/style.css', '/* Theme Name: Test Theme */');
-        \file_put_contents($themeDir . '/functions.php', '<?php // Test theme functions');
-        $result = \fwrite(STDOUT, "Test theme created at $themeDir\n");
-        if ($result === false) {
-            throw new \Exception("Failed to create test theme at $themeDir");
-        }
-    }
+	    if ($result === false) {
+		    throw new \Exception("Failed to create test theme at $themeDir");
+	    }
 
-    private function deleteDefaultTheme(): void
-    {
-        $themeDir = ABSPATH . 'wp-content/themes/test-theme';
-        if (!\is_dir($themeDir)) {
-            \fwrite(STDOUT, "Test theme not found at $themeDir\n");
-            return;
-        }
-
-        \array_map('unlink', (array) \glob($themeDir . '/*.*'));
-        \rmdir($themeDir);
-        \fwrite(STDOUT, "Test theme deleted from $themeDir\n");
+        \fwrite(STDOUT, "Test theme created at $themeDir\n");
     }
 
     /**

--- a/tests/src/IntegrationTestsExtension.php
+++ b/tests/src/IntegrationTestsExtension.php
@@ -191,14 +191,14 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
     private function createThemesFolder(): void
     {
         $themeDir = ABSPATH . 'wp-content/themes';
-		$result = true;
+        $result = true;
         if (!\is_dir($themeDir)) {
-	        $result = \mkdir($themeDir, 0755, true);
+            $result = \mkdir($themeDir, 0755, true);
         }
 
-	    if ($result === false) {
-		    throw new \Exception("Failed to create test theme at $themeDir");
-	    }
+        if ($result === false) {
+            throw new \Exception("Failed to create test theme at $themeDir");
+        }
 
         \fwrite(STDOUT, "Test theme created at $themeDir\n");
     }

--- a/tests/src/IntegrationTestsExtension.php
+++ b/tests/src/IntegrationTestsExtension.php
@@ -150,6 +150,7 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
         static::runWpCliCommand(['config', 'set', 'SAVEQUERIES', 'true']);
 
         static::resetDb();
+        $this->createDefaultTheme();
     }
 
     /**
@@ -158,6 +159,7 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
     public function executeAfterLastTest(): void
     {
         $this->resetWpConfig(true);
+        $this->deleteDefaultTheme();
     }
 
     /**
@@ -185,6 +187,34 @@ class IntegrationTestsExtension implements BeforeFirstTestHook, AfterLastTestHoo
         }
 
         return true;
+    }
+
+    private function createDefaultTheme(): void
+    {
+        $themeDir = ABSPATH . 'wp-content/themes/test-theme';
+        if (!\is_dir($themeDir)) {
+            \mkdir($themeDir, 0755, true);
+        }
+
+        \file_put_contents($themeDir . '/style.css', '/* Theme Name: Test Theme */');
+        \file_put_contents($themeDir . '/functions.php', '<?php // Test theme functions');
+        $result = \fwrite(STDOUT, "Test theme created at $themeDir\n");
+        if ($result === false) {
+            throw new \Exception("Failed to create test theme at $themeDir");
+        }
+    }
+
+    private function deleteDefaultTheme(): void
+    {
+        $themeDir = ABSPATH . 'wp-content/themes/test-theme';
+		if (!\is_dir($themeDir)) {
+			\fwrite(STDOUT, "Test theme not found at $themeDir\n");
+			return;
+		}
+
+        \array_map('unlink', (array) \glob($themeDir . '/*.*'));
+        \rmdir($themeDir);
+        \fwrite(STDOUT, "Test theme deleted from $themeDir\n");
     }
 
     /**


### PR DESCRIPTION
Fixes the existing issue with WP 6.8
The error was:
Function wp_is_block_theme was called <strong>incorrectly</strong>. This function should not be called before the theme directory is registered. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.8.0.) in /var/www/html/vendor/roots/wordpress-no-content/wp-includes/functions.php on line 6121