### PR TITLE
refactor(logUnfinishedHooks): method for improved readability and simplicity

### DIFF
--- a/src/HookListener/CronDebugListener.php
+++ b/src/HookListener/CronDebugListener.php
@@ -154,13 +154,12 @@ final class CronDebugListener implements ActionListener
     {
         $unfinished = [];
         foreach ($this->done as $hook => [, $duration]) {
-            if ($duration !== null) {
-                continue;
+            if ($duration === null) {
+                $unfinished[] = $hook;
             }
-            $unfinished[] = $hook;
         }
 
-        if (!$unfinished) {
+        if (empty($unfinished)) {
             return;
         }
 


### PR DESCRIPTION
Replaced negation check (`!== null`) with a more straightforward `=== null` check. 
Simplified the condition for checking if the $unfinished array is empty using `empty()` instead of `!$unfinished`