### PR TITLE
refactor(listenAll): precompute priority fallback before looping hooks

### DIFF
--- a/src/Registry/HookListenersRegistry.php
+++ b/src/Registry/HookListenersRegistry.php
@@ -51,8 +51,9 @@ class HookListenersRegistry
 
         foreach ($this->listeners as [$listener, $priority]) {
             $hooks = $listener->listenTo();
+            $priority = $priority ?? $defaultPriority;
             foreach ($hooks as $hook) {
-                $this->listenHook($hook, $priority ?? $defaultPriority, $listener);
+                $this->listenHook($hook, $priority, $listener);
             }
         }
     }


### PR DESCRIPTION
optimized priority check, now done once per listener instead of per hook. same result and less work.