### PR TITLE
refactor(hasAnyProcessorForChannel): optimize processor check loop

### DIFF
--- a/src/Registry/ProcessorsRegistry.php
+++ b/src/Registry/ProcessorsRegistry.php
@@ -177,7 +177,7 @@ class ProcessorsRegistry implements \Countable
      */
     public function hasAnyProcessorForChannel(string $channel): bool
     {
-        foreach (array_keys($this->processors) as $identifier) {
+        foreach ($this->processors as $identifier => $unused) {
             if ($this->hasProcessorForChannel($identifier, $channel)) {
                 return true;
             }


### PR DESCRIPTION
replace `array_keys()` with direct key-value `foreach` to avoid temporary array allocation