### PR TITLE
refactor: ensure serializeContext() always receives array input

### DIFF
--- a/src/LogActionUpdater.php
+++ b/src/LogActionUpdater.php
@@ -74,8 +74,12 @@ class LogActionUpdater
         $context = $log->context();
 
         $filteredContext = apply_filters(self::FILTER_CONTEXT, $context, $log);
-        if (!is_array($filteredContext)) {
-            $context = $filteredContext;
+        if (is_array($filteredContext)) {
+            return Serializer::serializeContext($filteredContext);
+        }
+
+        if ($filteredContext instanceof \Traversable) {
+            return Serializer::serializeContext(iterator_to_array($filteredContext));
         }
 
         return Serializer::serializeContext($context);


### PR DESCRIPTION
The old implementation of parseContext() could result in an iterable (e.g. Traversable)
being passed directly to serializeContext(), which explicitly requires an array type.
Although maybeMaskInput() internally accepts iterables, serializeContext() has a strict
array signature and would trigger a type error when passed a non-array iterable.

This refactor explicitly converts Traversable instances to arrays before calling
serializeContext(). It also simplifies the control flow using early returns for
better readability and aligns with static analysis and coding standards.

This change avoids type mismatches and ensures compatibility with PHP’s strict type
declarations while preserving the flexibility of filterable context data.
