### PR TITLE
Run integration tests alson in PHP 8.3 and 8.4

### DIFF
--- a/.github/workflows/docker/docker-compose.yml
+++ b/.github/workflows/docker/docker-compose.yml
@@ -45,3 +45,25 @@ services:
           *db-environment
         volumes:
           *wp-volume
+    php83:
+        container_name: wonolog-php-83
+        build:
+            context: .
+            dockerfile: ./php83/Dockerfile
+        depends_on:
+            - db
+        environment:
+          *db-environment
+        volumes:
+          *wp-volume
+    php84:
+        container_name: wonolog-php-84
+        build:
+            context: .
+            dockerfile: ./php84/Dockerfile
+        depends_on:
+            - db
+        environment:
+          *db-environment
+        volumes:
+          *wp-volume

--- a/.github/workflows/docker/php83/Dockerfile
+++ b/.github/workflows/docker/php83/Dockerfile
@@ -1,0 +1,15 @@
+FROM wordpress:cli-php8.3
+
+USER root
+
+RUN set -eux; apk update && apk add git
+
+COPY install-composer.sh /usr/bin/install-composer.sh
+RUN chmod +x /usr/bin/install-composer.sh && /usr/bin/install-composer.sh && mv composer.phar /usr/local/bin/composer
+
+COPY wait-for.sh /usr/bin/wait-for.sh
+RUN chmod +x /usr/bin/wait-for.sh
+
+RUN git config --global --add safe.directory /var/www/html
+
+WORKDIR /var/www/html

--- a/.github/workflows/docker/php84/Dockerfile
+++ b/.github/workflows/docker/php84/Dockerfile
@@ -1,0 +1,15 @@
+FROM wordpress:cli-php8.4
+
+USER root
+
+RUN set -eux; apk update && apk add git
+
+COPY install-composer.sh /usr/bin/install-composer.sh
+RUN chmod +x /usr/bin/install-composer.sh && /usr/bin/install-composer.sh && mv composer.phar /usr/local/bin/composer
+
+COPY wait-for.sh /usr/bin/wait-for.sh
+RUN chmod +x /usr/bin/wait-for.sh
+
+RUN git config --global --add safe.directory /var/www/html
+
+WORKDIR /var/www/html

--- a/.github/workflows/php-integration-tests.yml
+++ b/.github/workflows/php-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-service: [ '81', '82' ]
+                php-service: [ '81', '82', '83', '84' ]
                 dependency-versions: [ 'lowest', 'highest' ]
         steps:
             -   name: Checkout


### PR DESCRIPTION
Extend GitHub action workflow and related Dockerfiles to run integration tests in PHP 8.3 and 8.4