### PR TITLE
Extend CS check to test files

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,11 +9,11 @@
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Check for cross-version support for PHP 8.1 and higher. -->
-    <config name="testVersion" value="8.1-8.2" />
+    <config name="testVersion" value="8.1-" />
 
     <file>./inc</file>
     <file>./src</file>
-    <file>./tests/src</file>
+    <file>./tests</file>
 
     <!-- Use colors, and show sniff error codes and progress. -->
     <arg name="colors" />
@@ -35,9 +35,32 @@
     <rule ref="WordPress.Security.EscapeOutput.ExceptionNotEscaped">
         <exclude-pattern>/tests/*</exclude-pattern>
     </rule>
-
     <rule ref="WordPress.WP.AlternativeFunctions">
         <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.PHP.Eval.Discouraged">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="Syde.Functions.FunctionLength">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.PHP.DevelopmentFunctions">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.PHP.NoSilencedErrors">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ForbiddenPublicProperty">
+        <exclude-pattern>/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <exclude-pattern>/tests/stubs/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <exclude-pattern>/tests/stubs/*</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,8 @@
 <?php
 
-// phpcs:disable PSR1.Files.SideEffects
-// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions
-// phpcs:disable WordPress.PHP.DevelopmentFunctions
-
 declare(strict_types=1);
+
+// phpcs:disable PSR1
 
 $testsDir = str_replace('\\', '/', __DIR__);
 $libDir = dirname($testsDir);
@@ -20,7 +18,7 @@ putenv('LIBRARY_PATH=' . $libDir);
 putenv('VENDOR_DIR=' . $vendorDir);
 
 error_reporting(E_ALL);
-ini_set('error_reporting', '-1');
+ini_set('error_reporting', '-1'); // phpcs:ignore WordPress.PHP.IniSet
 
 require_once "{$vendorDir}/antecedent/patchwork/Patchwork.php";
 
@@ -33,7 +31,10 @@ if (!getenv('GITHUB_WORKFLOW') && file_exists(__DIR__ . '/environment.php')) {
     require_once __DIR__ . '/environment.php';
 }
 
-defined('ABSPATH') or define('ABSPATH', "{$vendorDir}/roots/wordpress-no-content/");
+if (!defined('ABSPATH')) {
+    define('ABSPATH', "{$vendorDir}/roots/wordpress-no-content/");
+}
+
 require_once ABSPATH . '/wp-includes/PHPMailer/SMTP.php';
 require_once ABSPATH . '/wp-includes/PHPMailer/PHPMailer.php';
 

--- a/tests/integration/AdvancedConfigTest.php
+++ b/tests/integration/AdvancedConfigTest.php
@@ -10,6 +10,7 @@ use Inpsyde\Wonolog\Data\Notice;
 use Inpsyde\Wonolog\DefaultHandler\FileHandler;
 use Inpsyde\Wonolog\HookListener\ActionListener;
 use Inpsyde\Wonolog\HookListener\QueryErrorsListener;
+use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\Tests\IntegrationTestCase;
 use Monolog\Handler\TestHandler;
@@ -17,7 +18,6 @@ use Monolog\LogRecord;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\AssertionFailedError;
 use Psr\Log\LogLevel;
-use Inpsyde\Wonolog\Levels;
 
 use function Inpsyde\Wonolog\makeLogger;
 
@@ -26,14 +26,7 @@ use function Inpsyde\Wonolog\makeLogger;
  */
 class AdvancedConfigTest extends IntegrationTestCase
 {
-    /**
-     * @var string
-     */
     private ?string $logFile = null;
-
-    /**
-     * @var TestHandler
-     */
     private ?TestHandler $testHandler = null;
 
     /**
@@ -329,10 +322,11 @@ class AdvancedConfigTest extends IntegrationTestCase
         $context and $messageLog .= sprintf(' (%s)', json_encode($context));
 
         $lines = @file($this->logFile) ?: [];
-        $found = false;
         foreach ((array) $lines as $line) {
             preg_match(
-                '~^\[[^\]]+\] (?<channel>[A-Z_-]+)\.(?<level>[A-Z]+): (?<txt>[^\[\{]+) (?<more>.+?)$~',
+                '~^\[[^\]]+\] '
+                . '(?<channel>[A-Z_-]+)\.(?<level>[A-Z]+): (?<txt>[^\[\{]+) '
+                . '(?<more>.+?)$~',
                 trim($line),
                 $matches
             );

--- a/tests/integration/BasicConfigTest.php
+++ b/tests/integration/BasicConfigTest.php
@@ -8,7 +8,6 @@ use Inpsyde\Wonolog\Channels;
 use Inpsyde\Wonolog\Configurator;
 use Inpsyde\Wonolog\Tests\IntegrationTestCase;
 use Monolog\Handler\TestHandler;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 use function Inpsyde\Wonolog\makeLogger;
@@ -18,10 +17,7 @@ use function Inpsyde\Wonolog\makeLogger;
  */
 class BasicConfigTest extends IntegrationTestCase
 {
-    /**
-     * @var TestHandler
-     */
-    private $handler;
+    private TestHandler $handler;
 
     /**
      * @param Configurator $configurator
@@ -80,7 +76,7 @@ class BasicConfigTest extends IntegrationTestCase
     /**
      * @test
      */
-    public function testLevelRichHook()
+    public function testLevelRichHook(): void
     {
         do_action('wonolog.log.info', 'Hello, I\'m there');
 
@@ -90,7 +86,7 @@ class BasicConfigTest extends IntegrationTestCase
     /**
      * @test
      */
-    public function testPsrLogger()
+    public function testPsrLogger(): void
     {
         $logger = makeLogger('test');
         $logger->alert('From PSR-3 with love.', ['foo' => 'bar']);

--- a/tests/stubs/constants.php
+++ b/tests/stubs/constants.php
@@ -1,9 +1,11 @@
 <?php
 
-if (! defined('PHP_INT_MIN')) {
-    define('PHP_INT_MIN', /** @var int */ ~\PHP_INT_MAX);
+declare(strict_types=1);
+
+if (!defined('PHP_INT_MIN')) {
+    define('PHP_INT_MIN', PHP_INT_MIN);
 }
 
-if (! defined('REST_REQUEST')) {
-    define('REST_REQUEST', /** @var ?bool */ false);
+if (!defined('REST_REQUEST')) {
+    define('REST_REQUEST', false);
 }

--- a/tests/stubs/wpdb.php
+++ b/tests/stubs/wpdb.php
@@ -1,11 +1,8 @@
 <?php
 
-// phpcs:disable PSR1
-// phpcs:disable Inpsyde.CodeQuality.ForbiddenPublicProperty
-// phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-// phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
-
 declare(strict_types=1);
+
+// phpcs:disable PSR1
 
 use Inpsyde\Wonolog\HookListener\WpDieHandlerListener;
 use Inpsyde\Wonolog\LogActionUpdater;
@@ -14,7 +11,7 @@ if (class_exists('wpdb')) {
     return;
 }
 
-class wpdb // phpcs:ignore
+class wpdb
 {
     public WpDieHandlerListener $wp_die_listener;
     public LogActionUpdater $logActionUpdater;
@@ -24,7 +21,7 @@ class wpdb // phpcs:ignore
      * @param string $code
      * @return string
      */
-    public function bail($message, $code = '500')
+    public function bail(string $message, string $code = '500'): string
     {
         $handler = $this->execute_die_listener();
 
@@ -35,7 +32,7 @@ class wpdb // phpcs:ignore
      * @param string $message
      * @return string
      */
-    public function print_error($message = '')
+    public function print_error(string $message = ''): string
     {
         $handler = $this->execute_die_listener();
 
@@ -43,7 +40,7 @@ class wpdb // phpcs:ignore
     }
 
     /**
-     * @return callable(string): string
+     * @return callable(string):string
      */
     private function execute_die_listener(): callable
     {

--- a/tests/unit/ConfiguratorTest.php
+++ b/tests/unit/ConfiguratorTest.php
@@ -109,7 +109,8 @@ class ConfiguratorTest extends UnitTestCase
         Monkey\Actions\expectDone(Configurator::ACTION_LOADED)->once();
 
         $factory = Factory::new();
-        $config = new class($factory) extends Configurator {
+        $config = new class ($factory) extends Configurator
+        {
             public function __construct(Factory $factory)
             {
                 parent::__construct($factory);
@@ -149,7 +150,8 @@ class ConfiguratorTest extends UnitTestCase
         Monkey\Actions\expectDone(Configurator::ACTION_LOADED)->once();
 
         $factory = Factory::new();
-        $config = new class($factory) extends Configurator {
+        $config = new class ($factory) extends Configurator
+        {
             public function __construct(Factory $factory)
             {
                 parent::__construct($factory);
@@ -187,7 +189,8 @@ class ConfiguratorTest extends UnitTestCase
         Monkey\Actions\expectDone(Configurator::ACTION_LOADED)->once();
 
         $factory = Factory::new();
-        $config = new class($factory) extends Configurator {
+        $config = new class ($factory) extends Configurator
+        {
             public function __construct(Factory $factory)
             {
                 parent::__construct($factory);
@@ -224,7 +227,8 @@ class ConfiguratorTest extends UnitTestCase
         Monkey\Actions\expectDone(Configurator::ACTION_LOADED)->once();
 
         $factory = Factory::new();
-        $config = new class($factory) extends Configurator {
+        $config = new class ($factory) extends Configurator
+        {
             public function __construct(Factory $factory)
             {
                 parent::__construct($factory);

--- a/tests/unit/Data/CustomLogDataTest.php
+++ b/tests/unit/Data/CustomLogDataTest.php
@@ -16,7 +16,6 @@ use Inpsyde\Wonolog\Data\Notice;
 use Inpsyde\Wonolog\Data\Warning;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Monolog\Logger;
 
 class CustomLogDataTest extends UnitTestCase
 {

--- a/tests/unit/Data/FailedLoginTest.php
+++ b/tests/unit/Data/FailedLoginTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Inpsyde\Wonolog\Tests\Unit\Data;
 
+use Brain\Monkey\Functions;
 use Inpsyde\Wonolog\Channels;
+use Inpsyde\Wonolog\Data\FailedLogin;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Inpsyde\Wonolog\Data\FailedLogin;
-use Brain\Monkey\Functions;
-use Monolog\Logger;
 
 class FailedLoginTest extends UnitTestCase
 {
@@ -20,11 +19,7 @@ class FailedLoginTest extends UnitTestCase
     {
         $transient = false;
 
-        // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-        // phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
-        $callback = static function (string $name, $value = null) use (&$transient) {
-            // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-            // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
+        $callback = static function (string $name, mixed $value = null) use (&$transient): bool {
             if ($value === null) {
                 return $transient;
             }
@@ -93,11 +88,7 @@ class FailedLoginTest extends UnitTestCase
     {
         $transient = false;
 
-        // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-        // phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
-        $callback = static function (string $name, $value = null) use (&$transient) {
-            // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-            // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
+        $callback = static function (string $name, mixed $value = null) use (&$transient): bool {
             if ($value === null) {
                 return $transient;
             }

--- a/tests/unit/Data/FailedLoginTest.php
+++ b/tests/unit/Data/FailedLoginTest.php
@@ -18,12 +18,10 @@ class FailedLoginTest extends UnitTestCase
     public function testData(): void
     {
         $transient = false;
-
-        $callback = static function (string $name, mixed $value = null) use (&$transient): bool {
+        $callback = static function (string $name, mixed $value = null) use (&$transient): mixed {
             if ($value === null) {
                 return $transient;
             }
-
             $transient = $value;
 
             return true;
@@ -88,11 +86,10 @@ class FailedLoginTest extends UnitTestCase
     {
         $transient = false;
 
-        $callback = static function (string $name, mixed $value = null) use (&$transient): bool {
+        $callback = static function (string $name, mixed $value = null) use (&$transient): mixed {
             if ($value === null) {
                 return $transient;
             }
-
             $transient = $value;
 
             return true;

--- a/tests/unit/Data/LogTest.php
+++ b/tests/unit/Data/LogTest.php
@@ -98,7 +98,7 @@ class LogTest extends UnitTestCase
         static::assertSame('Fail!, Fail!', $log->message());
         static::assertSame(Levels::ERROR, $log->level());
         static::assertArrayHasKey('throwable', $context);
-        static::assertSame($context['throwable']['class'], \Exception::class);
+        static::assertSame($context['throwable']['class'], get_class($exception));
         static::assertSame($context['throwable']['file'], __FILE__);
         static::assertArrayHasKey('line', $context['throwable']);
         static::assertArrayHasKey('trace', $context['throwable']);
@@ -120,7 +120,7 @@ class LogTest extends UnitTestCase
         static::assertSame('Fail!, Fail!', $log->message());
         static::assertSame(Levels::DEBUG, $log->level());
         static::assertArrayHasKey('throwable', $context);
-        static::assertSame($context['throwable']['class'], \Exception::class);
+        static::assertSame($context['throwable']['class'], get_class($exception));
         static::assertSame($context['throwable']['file'], __FILE__);
         static::assertArrayHasKey('line', $context['throwable']);
         static::assertArrayHasKey('trace', $context['throwable']);
@@ -142,7 +142,7 @@ class LogTest extends UnitTestCase
         static::assertSame('Fail!, Fail!', $log->message());
         static::assertSame(Levels::NOTICE, $log->level());
         static::assertArrayHasKey('throwable', $context);
-        static::assertSame($context['throwable']['class'], \Exception::class);
+        static::assertSame($context['throwable']['class'], get_class($exception));
         static::assertSame($context['throwable']['file'], __FILE__);
         static::assertArrayHasKey('line', $context['throwable']);
         static::assertArrayHasKey('trace', $context['throwable']);

--- a/tests/unit/DefaultHandler/BufferedFileHandlerTest.php
+++ b/tests/unit/DefaultHandler/BufferedFileHandlerTest.php
@@ -57,7 +57,7 @@ class BufferedFileHandlerTest extends UnitTestCase
         $this->setupFolders();
         $handler = FileHandler::new();
         $formatter = new JsonFormatter();
-        $processor = static function (array $record): array { return $record; };
+        $processor = static fn (array $record): array => $record;
         $handler->setFormatter($formatter);
         $handler->pushProcessor($processor);
 

--- a/tests/unit/DefaultHandler/LogsFolderTest.php
+++ b/tests/unit/DefaultHandler/LogsFolderTest.php
@@ -18,7 +18,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineDefaultWhenUploadsInsideContent()
+    public function testDetermineDefaultWhenUploadsInsideContent(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -32,7 +32,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineDefaultWhenUploadsOutsideContent()
+    public function testDetermineDefaultWhenUploadsOutsideContent(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders(false);
@@ -46,7 +46,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineDefaultWhenUploadsOutsideContentButErrored()
+    public function testDetermineDefaultWhenUploadsOutsideContentButErrored(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders(false, false);
@@ -60,7 +60,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineDefaultWhenWpLogConstantDefinedAsPath()
+    public function testDetermineDefaultWhenWpLogConstantDefinedAsPath(): void
     {
         $dir = $this->setupFolders();
         define('WP_DEBUG_LOG', $dir->url() . '/tmp/wp.log');
@@ -74,7 +74,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineDefaultWhenErrorLogFileConstantDefinedAsPath()
+    public function testDetermineDefaultWhenErrorLogFileConstantDefinedAsPath(): void
     {
         $dir = $this->setupFolders();
         define('WP_DEBUG_LOG', true);
@@ -89,7 +89,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineCustomWhenUploadsInsideContentWithAppendedWonologDir()
+    public function testDetermineCustomWhenUploadsInsideContentWithAppendedWonologDir(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -103,7 +103,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineCustomWhenUploadsInsideContentWithoutAppendedWonologDir()
+    public function testDetermineCustomWhenUploadsInsideContentWithoutAppendedWonologDir(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -117,7 +117,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineCustomInWpContentWithAppendedWonologDir()
+    public function testDetermineCustomInWpContentWithAppendedWonologDir(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -131,7 +131,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineCustomInWpContentWithoutAppendedWonologDir()
+    public function testDetermineCustomInWpContentWithoutAppendedWonologDir(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -145,7 +145,7 @@ class LogsFolderTest extends UnitTestCase
     /**
      * @test
      */
-    public function testDetermineCustomOutsidePublic()
+    public function testDetermineCustomOutsidePublic(): void
     {
         define('WP_DEBUG_LOG', true);
         $dir = $this->setupFolders();
@@ -161,14 +161,17 @@ class LogsFolderTest extends UnitTestCase
      * @param bool $uploadsOk
      * @return vfsStreamDirectory
      */
-    private function setupFolders(bool $uploadsNested = true, $uploadsOk = true): vfsStreamDirectory
-    {
+    private function setupFolders(
+        bool $uploadsNested = true,
+        bool $uploadsOk = true
+    ): vfsStreamDirectory {
+
         $dir = vfsStream::setup('root', 0777);
         $structure = [
             'tmp' => [],
             'www' => [
                 'wp' => ['wp-includes' => [], 'wp-admin' => []],
-                'wp-content' => []
+                'wp-content' => [],
             ],
         ];
 
@@ -181,10 +184,14 @@ class LogsFolderTest extends UnitTestCase
         define('WP_CONTENT_DIR', $dir->url() . '/www/wp-content');
 
         Monkey\Functions\when('wp_upload_dir')
-            ->alias(static function () use ($uploadsNested, $uploadsOk, $dir): array {
-                $path = $uploadsNested ? '/www/wp-content/uploads' : '/www/uploads';
-                return $uploadsOk ? ['basedir' => $dir->url() . $path] : ['error' => 'error'];
-            });
+            ->alias(
+                static function () use ($uploadsNested, $uploadsOk, $dir): array {
+                    $path = $uploadsNested ? '/www/wp-content/uploads' : '/www/uploads';
+                    return $uploadsOk
+                        ? ['basedir' => $dir->url() . $path]
+                        : ['error' => 'error'];
+                }
+            );
 
         return $dir;
     }

--- a/tests/unit/HookListener/CronDebugListenerTest.php
+++ b/tests/unit/HookListener/CronDebugListenerTest.php
@@ -6,11 +6,10 @@ namespace Inpsyde\Wonolog\Tests\Unit\HookListener;
 
 use Brain\Monkey;
 use Inpsyde\Wonolog\Data\LogData;
+use Inpsyde\Wonolog\HookListener\CronDebugListener;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Inpsyde\Wonolog\HookListener\CronDebugListener;
-use Monolog\Logger;
 
 class CronDebugListenerTest extends UnitTestCase
 {
@@ -55,19 +54,19 @@ class CronDebugListenerTest extends UnitTestCase
         $cb3 = null;
 
         Monkey\Actions\expectAdded('wp_version_check')->twice()->whenHappen(
-            static function ($profileCallback) use (&$cb1): void {
+            static function (callable $profileCallback) use (&$cb1): void {
                 $cb1 = $profileCallback;
             }
         );
 
         Monkey\Actions\expectAdded('wp_update_plugins')->twice()->whenHappen(
-            static function ($profileCallback) use (&$cb2): void {
+            static function (callable $profileCallback) use (&$cb2): void {
                 $cb2 = $profileCallback;
             }
         );
 
         Monkey\Actions\expectAdded('wp_scheduled_delete')->twice()->whenHappen(
-            static function ($profileCallback) use (&$cb3): void {
+            static function (callable $profileCallback) use (&$cb3): void {
                 $cb3 = $profileCallback;
             }
         );

--- a/tests/unit/HookListener/DbErrorListenerTest.php
+++ b/tests/unit/HookListener/DbErrorListenerTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Inpsyde\Wonolog\Tests\Unit\HookListener;
 
+use Brain\Monkey\Actions;
 use Inpsyde\Wonolog\Channels;
 use Inpsyde\Wonolog\Data\LogData;
+use Inpsyde\Wonolog\HookListener\DbErrorListener;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Inpsyde\Wonolog\HookListener\DbErrorListener;
-use Brain\Monkey\Actions;
 
 class DbErrorListenerTest extends UnitTestCase
 {
@@ -28,10 +28,10 @@ class DbErrorListenerTest extends UnitTestCase
      */
     public function testLogDone(): void
     {
-        // phpcs:disable Inpsyde.CodeQuality.VariablesName.SnakeCaseVar
-
+        // phpcs:disable Syde.NamingConventions.VariableName.SnakeCaseVar
         global $EZSQL_ERROR;
         $EZSQL_ERROR = [['query' => 'This is a SQL query', 'error_str' => 'This is an error']];
+        // phpcs:enable Syde.NamingConventions.VariableName.SnakeCaseVar
 
         $listener = new DbErrorListener();
 
@@ -40,13 +40,13 @@ class DbErrorListenerTest extends UnitTestCase
             ->with(\Mockery::type(LogData::class))
             ->andReturnUsing(
                 static function (LogData $log): void {
+                    // phpcs:disable Syde.NamingConventions.VariableName.SnakeCaseVar
                     global $EZSQL_ERROR;
                     $context = [
                         'last_wpdb_query' => 'This is a SQL query',
                         'last_wpdb_errors' => $EZSQL_ERROR,
                     ];
-                    // phpcs:enable Inpsyde.CodeQuality.VariablesName.SnakeCaseVar
-
+                    // phpcs:enable Syde.NamingConventions.VariableName.SnakeCaseVar
                     static::assertSame(Channels::DB, $log->channel());
                     static::assertSame('This is an error', $log->message());
                     static::assertEquals($context, $log->context());
@@ -69,10 +69,10 @@ class DbErrorListenerTest extends UnitTestCase
      */
     public function testLogNotDoneIfNoError(): void
     {
-        // phpcs:disable Inpsyde.CodeQuality.VariablesName.SnakeCaseVar
+        // phpcs:disable Syde.NamingConventions.VariableName.SnakeCaseVar
         global $EZSQL_ERROR;
         $EZSQL_ERROR = [];
-        // phpcs:enable Inpsyde.CodeQuality.VariablesName.SnakeCaseVar
+        // phpcs:enable Syde.NamingConventions.VariableName.SnakeCaseVar
 
         $listener = new DbErrorListener();
 

--- a/tests/unit/HookListener/HttpApiListenerTest.php
+++ b/tests/unit/HookListener/HttpApiListenerTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Inpsyde\Wonolog\Tests\Unit\HookListener;
 
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
 use Inpsyde\Wonolog\Channels;
 use Inpsyde\Wonolog\Data\LogData;
+use Inpsyde\Wonolog\HookListener\HttpApiListener;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Inpsyde\Wonolog\HookListener\HttpApiListener;
-use Brain\Monkey\Actions;
-use Brain\Monkey\Functions;
-use Monolog\Logger;
 
 class HttpApiListenerTest extends UnitTestCase
 {
@@ -49,8 +48,7 @@ class HttpApiListenerTest extends UnitTestCase
 
         Actions\expectDone('http_api_debug')
             ->whenHappen(
-            // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-                static function (...$args) use ($listener, $updater): void {
+                static function (mixed ...$args) use ($listener, $updater): void {
                     $listener->update('a', $args, $updater);
                 }
             );

--- a/tests/unit/HookListener/QueryErrorsListenerTest.php
+++ b/tests/unit/HookListener/QueryErrorsListenerTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Inpsyde\Wonolog\Tests\Unit\HookListener;
 
-use Inpsyde\Wonolog\Channels;
-use Inpsyde\Wonolog\Data\LogData;
-use Inpsyde\Wonolog\LogActionUpdater;
-use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Inpsyde\Wonolog\HookListener\QueryErrorsListener;
 use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
+use Inpsyde\Wonolog\Channels;
+use Inpsyde\Wonolog\Data\LogData;
+use Inpsyde\Wonolog\HookListener\QueryErrorsListener;
+use Inpsyde\Wonolog\LogActionUpdater;
+use Inpsyde\Wonolog\Tests\UnitTestCase;
 
 class QueryErrorsListenerTest extends UnitTestCase
 {
@@ -52,9 +52,7 @@ class QueryErrorsListenerTest extends UnitTestCase
 
         Actions\expectDone('wp')
             ->whenHappen(
-            // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-                static function (...$args) use ($listener, $updater): void {
-                    // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+                static function (mixed ...$args) use ($listener, $updater): void {
                     $listener->update('a', $args, $updater);
                 }
             );

--- a/tests/unit/HookLogFactoryTest.php
+++ b/tests/unit/HookLogFactoryTest.php
@@ -12,7 +12,6 @@ use Inpsyde\Wonolog\Data\LogData;
 use Inpsyde\Wonolog\HookLogFactory;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Monolog\Logger;
 use Psr\Log\LogLevel;
 
 class HookLogFactoryTest extends UnitTestCase

--- a/tests/unit/LevelsTest.php
+++ b/tests/unit/LevelsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Inpsyde\Wonolog\Tests\Unit;
 
 use Inpsyde\Wonolog\Levels;

--- a/tests/unit/LogActionUpdaterTest.php
+++ b/tests/unit/LogActionUpdaterTest.php
@@ -12,7 +12,6 @@ use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\LogActionUpdater;
 use Inpsyde\Wonolog\LogLevel as WonologLogLevel;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Monolog\Logger;
 use Psr\Log\LogLevel;
 use Psr\Log\Test\TestLogger;
 
@@ -120,15 +119,15 @@ class LogActionUpdaterTest extends UnitTestCase
 
         $context = [
             'users' => [
-                (object)[
+                (object) [
                     'user_login' => 'foo',
                     'user_password' => 'secret1',
                 ],
-                (object)[
+                (object) [
                     'user_login' => 'bar',
                     'user_password' => 'secret2',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $contextExpected = [
@@ -140,8 +139,8 @@ class LogActionUpdaterTest extends UnitTestCase
                 [
                     'user_login' => 'bar',
                     'user_password' => '***',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $log = new Log('Test me', Levels::EMERGENCY, Channels::SECURITY, $context);

--- a/tests/unit/LogLevelTest.php
+++ b/tests/unit/LogLevelTest.php
@@ -7,7 +7,6 @@ namespace Inpsyde\Wonolog\Tests\Unit;
 use Inpsyde\Wonolog\Levels;
 use Inpsyde\Wonolog\LogLevel;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Monolog\Logger;
 
 /**
  * @runTestsInSeparateProcesses

--- a/tests/unit/PhpErrorHandlerTest.php
+++ b/tests/unit/PhpErrorHandlerTest.php
@@ -101,7 +101,7 @@ class PhpErrorHandlerTest extends UnitTestCase
 
         try {
             throw new \RuntimeException('Exception!');
-        } catch (\Exception $throwable) {
+        } catch (\Throwable $throwable) {
             $controller->onException($throwable);
         }
     }

--- a/tests/unit/Processor/NullProcessorTest.php
+++ b/tests/unit/Processor/NullProcessorTest.php
@@ -35,7 +35,6 @@ class NullProcessorTest extends UnitTestCase
         $context = [
             'foo' => 'bar',
         ];
-        /** @var LogRecord $record */
         $record = new LogRecord(
             new \DateTimeImmutable(),
             $channel,
@@ -58,20 +57,19 @@ class NullProcessorTest extends UnitTestCase
     public function testProcessesArrayCorrectly(): void
     {
         $processor = new NullProcessor();
-        $message = 'mymessage';
+        $message = 'my-message';
         $level = Levels::ERROR;
-        $channel = 'mychannel'; // TODO: should we add this to the Record? looking for symmetry with LogRecord Model
+        $channel = 'my-channel';
         $context = [
             'foo' => 'bar',
         ];
-        /** @var array $record */
-        $record = compact('message', 'context', 'level');
-        /** @var array $record */
+        $record = compact('message', 'context', 'level', 'channel');
         $processedRecord = $processor($record);
 
         static::assertIsArray($processedRecord);
         static::assertEquals($processedRecord['message'], $message);
         static::assertEquals($processedRecord['context'], $context);
         static::assertEquals($processedRecord['level'], $level);
+        static::assertEquals($processedRecord['channel'], $channel);
     }
 }

--- a/tests/unit/PsrBridgeTest.php
+++ b/tests/unit/PsrBridgeTest.php
@@ -13,10 +13,7 @@ use Inpsyde\Wonolog\Tests\UnitTestCase;
 
 class PsrBridgeTest extends UnitTestCase
 {
-    /**
-     * @var LogData|null
-     */
-    private $logged;
+    private LogData|null $logged;
 
     /**
      * @return void
@@ -30,7 +27,7 @@ class PsrBridgeTest extends UnitTestCase
     /**
      * @test
      */
-    public function testAutoBuildLog()
+    public function testAutoBuildLog(): void
     {
         $bridge = $this->factoryBridge();
         $bridge->emergency('test {x}', ['x' => 'X!', 'y' => 'Y!']);
@@ -44,7 +41,7 @@ class PsrBridgeTest extends UnitTestCase
     /**
      * @test
      */
-    public function testBuildLogWithDefaultChannel()
+    public function testBuildLogWithDefaultChannel(): void
     {
         $bridge = $this->factoryBridge('CUSTOM');
         $bridge->emergency('test {x}', ['x' => 'X!', 'y' => 'Y!']);
@@ -58,7 +55,7 @@ class PsrBridgeTest extends UnitTestCase
     /**
      * @test
      */
-    public function testBuildLogWithManualChannel()
+    public function testBuildLogWithManualChannel(): void
     {
         $bridge = $this->factoryBridge()->withDefaultChannel('MY_PLUGIN');
         $bridge->emergency('test {x}', ['x' => 'X!', 'y' => 'Y!']);
@@ -72,7 +69,7 @@ class PsrBridgeTest extends UnitTestCase
     /**
      * @test
      */
-    public function testBuildLogWithManualChannelFromBadLevel()
+    public function testBuildLogWithManualChannelFromBadLevel(): void
     {
         $bridge = $this->factoryBridge()->withDefaultChannel('MY_PLUGIN');
         $bridge->log('foo', 'test {x}', ['x' => 'X!', 'y' => 'Y!']);

--- a/tests/unit/SerializerTest.php
+++ b/tests/unit/SerializerTest.php
@@ -17,7 +17,7 @@ class SerializerTest extends UnitTestCase
      * @test
      * @dataProvider provideMessageExamples
      */
-    public function testMessageSerialization($message, string $expected): void
+    public function testMessageSerialization(mixed $message, string $expected): void
     {
         static::assertSame($expected, Serializer::serializeMessage($message));
     }
@@ -36,7 +36,7 @@ class SerializerTest extends UnitTestCase
      */
     public function testMessageSerializationWithException(): void
     {
-        static::assertSame('Error: Error!',  Serializer::serializeMessage(new \Error('Error!')));
+        static::assertSame('Error: Error!', Serializer::serializeMessage(new \Error('Error!')));
     }
 
     /**
@@ -46,11 +46,12 @@ class SerializerTest extends UnitTestCase
     {
         Monkey\Filters\expectApplied(Serializer::FILTER_MASKED_KEYS)
             ->once()
-            ->andReturnUsing(static function (array $keys): array {
-                $keys[]  = 'secret_key';
-
-                return $keys;
-            });
+            ->andReturnUsing(
+                static function (array $keys): array {
+                    $keys[] = 'secret_key';
+                    return $keys;
+                }
+            );
 
         if (!class_exists(\WP_Post::class)) {
             eval('class WP_Post { public $ID = null; }');
@@ -77,26 +78,26 @@ class SerializerTest extends UnitTestCase
         $throwable = new \Error('Foo');
         $datetime = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
-        $jsonScalar = new class implements \JsonSerializable {
-            #[\ReturnTypeWillChange]
-            public function jsonSerialize()
+        $jsonScalar = new class implements \JsonSerializable
+        {
+            public function jsonSerialize(): int
             {
                 return 1;
             }
         };
 
-        $jsonObj = new class implements \JsonSerializable {
-            #[\ReturnTypeWillChange]
-            public function jsonSerialize()
+        $jsonObj = new class implements \JsonSerializable
+        {
+            public function jsonSerialize(): object
             {
-                return (object)['token' => 'x'];
+                return (object) ['token' => 'x'];
             }
         };
 
         $input = [
             'array' => range('a', 'e'),
             'x' => [
-                'y' => (object)[
+                'y' => (object) [
                     'users' => [
                         'z1' => new \ArrayIterator([
                             ['username' => 'foo', 'password' => 's3cr3t1'],
@@ -106,13 +107,13 @@ class SerializerTest extends UnitTestCase
                             ['username' => 'foo', 'user_password' => 's3cr3t1'],
                             ['username' => 'bar', 'user_password' => 's3cr3t2'],
                         ]),
-                    ]
+                    ],
                 ],
             ],
-            'secrets' => (object)[
-                'one' => (object)['name' => 'one', 'secret_key' => '0n3!'],
-                'two' => (object)['name' => 'two', 'secret_key' => 'Tw0!'],
-                'three' => (object)['name' => 'three', 'secret_key' => 'Thr33!'],
+            'secrets' => (object) [
+                'one' => (object) ['name' => 'one', 'secret_key' => '0n3!'],
+                'two' => (object) ['name' => 'two', 'secret_key' => 'Tw0!'],
+                'three' => (object) ['name' => 'three', 'secret_key' => 'Thr33!'],
             ],
             'posts' => compact('post1', 'post2', 'post3'),
             'data' => [
@@ -136,7 +137,7 @@ class SerializerTest extends UnitTestCase
                             ['username' => 'foo', 'user_password' => '***'],
                             ['username' => 'bar', 'user_password' => '***'],
                         ],
-                    ]
+                    ],
                 ],
             ],
             'secrets' => [
@@ -177,8 +178,8 @@ class SerializerTest extends UnitTestCase
             [1.05, '1.05'],
             [NAN, 'NaN'],
             [INF, 'INF'],
-            [- INF, '-INF'],
-            [(object)['foo' => 'bar'], '{"foo":"bar"}'],
+            [-INF, '-INF'],
+            [(object) ['foo' => 'bar'], '{"foo":"bar"}'],
             [['foo' => 'bar'], '{"foo":"bar"}'],
         ];
     }

--- a/tests/unit/WpErrorChannelTest.php
+++ b/tests/unit/WpErrorChannelTest.php
@@ -6,8 +6,8 @@ namespace Inpsyde\Wonolog\Tests\Unit;
 
 use Brain\Monkey\Filters;
 use Inpsyde\Wonolog\Channels;
-use Inpsyde\Wonolog\WpErrorChannel;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
+use Inpsyde\Wonolog\WpErrorChannel;
 
 class WpErrorChannelTest extends UnitTestCase
 {


### PR DESCRIPTION
- Check for coding standards in the test folder and change all the files ot make it pass.
- Cleanup of "old" Inpsyde CS in "ignore comments"

Zero functional change.