### PR TITLE
Rename default "HTTP" channel to "NETWORK"

### DIFF
--- a/src/Channels.php
+++ b/src/Channels.php
@@ -11,7 +11,7 @@ use Psr\Log\NullLogger;
 
 class Channels
 {
-    public const HTTP = 'HTTP';
+    public const NETWORK = 'HTTP'; // Backward compatibility
     public const DB = 'DB';
     public const PHP_ERROR = 'PHP-ERROR';
     public const SECURITY = 'SECURITY';
@@ -20,8 +20,11 @@ class Channels
     public const ACTION_LOGGER = 'wonolog.logger';
     public const ACTION_MONOLOG_LOGGER = 'wonolog.monolog-logger';
 
+    /** @deprecated */
+    public const HTTP = self::NETWORK;
+
     public const CHANNELS = [
-        self::HTTP,
+        self::NETWORK,
         self::DB,
         self::PHP_ERROR,
         self::SECURITY,
@@ -32,7 +35,7 @@ class Channels
     ];
 
     public const DEFAULT_CHANNELS = [
-        self::HTTP,
+        self::NETWORK,
         self::DB,
         self::SECURITY,
         self::DEBUG,

--- a/src/HookListener/HttpApiListener.php
+++ b/src/HookListener/HttpApiListener.php
@@ -217,6 +217,6 @@ final class HttpApiListener implements ActionListener
             }
         }
 
-        return new Log($msg, $this->errorLogLevel, Channels::HTTP, $logContext);
+        return new Log($msg, $this->errorLogLevel, Channels::NETWORK, $logContext);
     }
 }

--- a/src/HookListener/MailerListener.php
+++ b/src/HookListener/MailerListener.php
@@ -70,7 +70,7 @@ class MailerListener implements ActionListener
     {
         $error = $args ? reset($args) : null;
         if ($error instanceof \WP_Error) {
-            $updater->update(Log::fromWpError($error, $this->errorLogLevel, Channels::HTTP));
+            $updater->update(Log::fromWpError($error, $this->errorLogLevel, Channels::NETWORK));
         }
     }
 
@@ -88,7 +88,7 @@ class MailerListener implements ActionListener
 
         $mailer->SMTPDebug = $this->smtpDebugLevel;
         $mailer->Debugoutput = static function (string $message) use ($updater): void {
-            $updater->update(new Debug($message, Channels::HTTP));
+            $updater->update(new Debug($message, Channels::NETWORK));
         };
     }
 }

--- a/src/HookListener/QueryErrorsListener.php
+++ b/src/HookListener/QueryErrorsListener.php
@@ -71,6 +71,6 @@ final class QueryErrorsListener implements ActionListener
             'matched_rule' => $wp->matched_rule,
         ];
 
-        $updater->update(new Log($message, $this->logLevel, Channels::HTTP, $context));
+        $updater->update(new Log($message, $this->logLevel, Channels::NETWORK, $context));
     }
 }

--- a/src/WpErrorChannel.php
+++ b/src/WpErrorChannel.php
@@ -82,7 +82,7 @@ class WpErrorChannel
             || stripos($code, 'wp_mail') !== false
             || stripos($code, 'email') !== false
         ) {
-            return Channels::HTTP;
+            return Channels::NETWORK;
         }
 
         return null;

--- a/tests/integration/AdvancedConfigTest.php
+++ b/tests/integration/AdvancedConfigTest.php
@@ -149,14 +149,14 @@ class AdvancedConfigTest extends IntegrationTestCase
             'wonolog.log',
             [
                 'message' => 'Something happened.',
-                'channel' => Channels::HTTP,
+                'channel' => Channels::NETWORK,
                 'level' => LogLevel::NOTICE,
             ]
         );
 
         static::assertFalse($this->testHandler->hasNoticeThatContains('Something happened.'));
 
-        $this->assertLogFileHasLine('Something happened.', Channels::HTTP, 'NOTICE');
+        $this->assertLogFileHasLine('Something happened.', Channels::NETWORK, 'NOTICE');
     }
 
     /**
@@ -266,7 +266,7 @@ class AdvancedConfigTest extends IntegrationTestCase
         $wp->matched_rule = 'rule';
         $wp->query_vars['error'] = 'Error one';
 
-        $expectedMessage = 'Error on frontend request';
+        $expectedMsg = 'Error on frontend request';
         $expectedContext = [
             'error' => ['Error one', '404 Page not found'],
             'query_vars' => ['error' => 'Error one'],
@@ -275,7 +275,7 @@ class AdvancedConfigTest extends IntegrationTestCase
 
         do_action('wp', $wp);
 
-        $this->assertLogFileHasLine($expectedMessage, Channels::HTTP, 'NOTICE', $expectedContext);
+        $this->assertLogFileHasLine($expectedMsg, Channels::NETWORK, 'NOTICE', $expectedContext);
         static::assertSame([], $this->testHandler->getRecords());
     }
 

--- a/tests/unit/ConfiguratorTest.php
+++ b/tests/unit/ConfiguratorTest.php
@@ -121,7 +121,7 @@ class ConfiguratorTest extends UnitTestCase
             ->doNotLogPhpErrorsNorExceptions()
             ->disableAllDefaultHookListeners()
             ->pushHandler(new NoopHandler())
-            ->removeHandlerFromChannels(NoopHandler::class, Channels::HTTP, Channels::DB)
+            ->removeHandlerFromChannels(NoopHandler::class, Channels::NETWORK, Channels::DB)
             ->disableFallbackHandlerForChannels(Channels::DB);
 
         $config->setup();
@@ -129,7 +129,7 @@ class ConfiguratorTest extends UnitTestCase
         $handlers = $factory->handlersRegistry();
 
         $debugHandlers = $handlers->findForChannel(Channels::DEBUG);
-        $httpHandlers = $handlers->findForChannel(Channels::HTTP);
+        $httpHandlers = $handlers->findForChannel(Channels::NETWORK);
         $dbHandlers = $handlers->findForChannel(Channels::DB);
 
         static::assertCount(1, $debugHandlers);

--- a/tests/unit/Data/LogTest.php
+++ b/tests/unit/Data/LogTest.php
@@ -133,12 +133,12 @@ class LogTest extends UnitTestCase
     {
         $exception = new \Exception('Fail!, Fail!', 123);
 
-        $log = Log::fromThrowable($exception, Levels::NOTICE, Channels::HTTP);
+        $log = Log::fromThrowable($exception, Levels::NOTICE, Channels::NETWORK);
         static::assertInstanceOf(Log::class, $log);
 
         $context = $log->context();
 
-        static::assertSame(Channels::HTTP, $log->channel());
+        static::assertSame(Channels::NETWORK, $log->channel());
         static::assertSame('Fail!, Fail!', $log->message());
         static::assertSame(Levels::NOTICE, $log->level());
         static::assertArrayHasKey('throwable', $context);
@@ -157,12 +157,12 @@ class LogTest extends UnitTestCase
             [
                 LogData::MESSAGE => 'message',
                 LogData::LEVEL => Levels::EMERGENCY,
-                LogData::CHANNEL => Channels::HTTP,
+                LogData::CHANNEL => Channels::NETWORK,
                 LogData::CONTEXT => ['foo'],
             ]
         );
 
-        static::assertSame(Channels::HTTP, $log->channel());
+        static::assertSame(Channels::NETWORK, $log->channel());
         static::assertSame('message', $log->message());
         static::assertSame(['foo'], $log->context());
         static::assertSame(Levels::EMERGENCY, $log->level());

--- a/tests/unit/HookListener/HttpApiListenerTest.php
+++ b/tests/unit/HookListener/HttpApiListenerTest.php
@@ -26,8 +26,8 @@ class HttpApiListenerTest extends UnitTestCase
             ->andReturnUsing(
                 static function (LogData $log): void {
                     static::assertSame('WP HTTP API Error: Test!', $log->message());
-                    static::assertSame(Channels::HTTP, $log->channel());
                     static::assertSame(Levels::ERROR, $log->level());
+                    static::assertSame(Channels::NETWORK, $log->channel());
                     static::assertSame(
                         [
                             'transport' => 'TestClass',
@@ -76,8 +76,8 @@ class HttpApiListenerTest extends UnitTestCase
             ->with(\Mockery::type(LogData::class))
             ->andReturnUsing(
                 static function (LogData $log): void {
-                    static::assertSame(Channels::HTTP, $log->channel());
                     static::assertSame(Levels::ERROR, $log->level());
+                    static::assertSame(Channels::NETWORK, $log->channel());
                     static::assertSame(
                         'WP HTTP API Error: Internal Server Error - Response code: 500',
                         $log->message()

--- a/tests/unit/HookListener/MailerListenerTest.php
+++ b/tests/unit/HookListener/MailerListenerTest.php
@@ -29,7 +29,7 @@ class MailerListenerTest extends UnitTestCase
             ->andReturnUsing(
                 static function (Debug $debug): void {
                     static::assertSame('Test email!', $debug->message());
-                    static::assertSame(Channels::HTTP, $debug->channel());
+                    static::assertSame(Channels::NETWORK, $debug->channel());
                 }
             );
 
@@ -65,7 +65,7 @@ class MailerListenerTest extends UnitTestCase
                 static function (LogData $log): void {
                     static::assertInstanceOf(LogData::class, $log);
                     static::assertSame(Levels::ERROR, $log->level());
-                    static::assertSame(Channels::HTTP, $log->channel());
+                    static::assertSame(Channels::NETWORK, $log->channel());
                 }
             );
 

--- a/tests/unit/HookListener/QueryErrorsListenerTest.php
+++ b/tests/unit/HookListener/QueryErrorsListenerTest.php
@@ -28,7 +28,7 @@ class QueryErrorsListenerTest extends UnitTestCase
             ->with(\Mockery::type(LogData::class))
             ->andReturnUsing(
                 static function (LogData $log): void {
-                    static::assertSame(Channels::HTTP, $log->channel());
+                    static::assertSame(Channels::NETWORK, $log->channel());
                     static::assertSame('Error on frontend request for url /meh.', $log->message());
                     static::assertSame(
                         [

--- a/tests/unit/Registry/HandlersRegistryTest.php
+++ b/tests/unit/Registry/HandlersRegistryTest.php
@@ -47,7 +47,7 @@ class HandlersRegistryTest extends UnitTestCase
 
         static::assertFalse($registry->hasHandlerForChannel('x', Channels::CRON));
         static::assertTrue($registry->hasHandlerForChannel('x', Channels::DEBUG));
-        static::assertTrue($registry->hasHandlerForChannel('x', Channels::HTTP));
+        static::assertTrue($registry->hasHandlerForChannel('x', Channels::NETWORK));
 
         static::assertCount(1, $registry);
     }
@@ -85,8 +85,8 @@ class HandlersRegistryTest extends UnitTestCase
 
         /** @var HandlerInterface $handler */
         $handler = \Mockery::mock(HandlerInterface::class);
-        $registry->addHandler($handler, 'X', Channels::HTTP, Channels::CRON);
-        $registry->removeHandlerFromChannels('X', Channels::HTTP);
+        $registry->addHandler($handler, 'X', Channels::NETWORK, Channels::CRON);
+        $registry->removeHandlerFromChannels('X', Channels::NETWORK);
         $registry->removeHandlerFromChannels('X', Channels::CRON);
 
         static::assertCount(0, $registry);
@@ -99,9 +99,9 @@ class HandlersRegistryTest extends UnitTestCase
     {
         $registry = Factory::new()->handlersRegistry();
 
-        $registry->addHandler(new TestHandler(), 'test', Channels::HTTP, Channels::CRON);
+        $registry->addHandler(new TestHandler(), 'test', Channels::NETWORK, Channels::CRON);
         $registry->addHandler(FileHandler::new(), 'default');
-        $registry->removeHandlerFromChannels('default', Channels::HTTP);
+        $registry->removeHandlerFromChannels('default', Channels::NETWORK);
 
         Actions\expectDone(HandlersRegistry::ACTION_SETUP)
             ->once()
@@ -123,7 +123,7 @@ class HandlersRegistryTest extends UnitTestCase
 
         static::assertCount(2, $registry);
 
-        $http = $registry->findForChannel(Channels::HTTP);
+        $http = $registry->findForChannel(Channels::NETWORK);
         static::assertCount(1, $http);
         static::assertInstanceOf(TestHandler::class, $http[0]);
 
@@ -141,7 +141,7 @@ class HandlersRegistryTest extends UnitTestCase
         static::assertInstanceOf(FileHandler::class, $db[0]);
 
         $registry->removeHandler('test');
-        static::assertSame([], $registry->findForChannel(Channels::HTTP));
+        static::assertSame([], $registry->findForChannel(Channels::NETWORK));
 
         $cronAgain = $registry->findForChannel(Channels::CRON);
         static::assertCount(1, $cronAgain);

--- a/tests/unit/WpErrorChannelTest.php
+++ b/tests/unit/WpErrorChannelTest.php
@@ -47,7 +47,7 @@ class WpErrorChannelTest extends UnitTestCase
         $instance = WpErrorChannel::new();
         $channel = $instance->channelFor($error);
 
-        static::assertSame(Channels::HTTP, $channel);
+        static::assertSame(Channels::NETWORK, $channel);
     }
 
     /**


### PR DESCRIPTION
The "HTTP" channel was used for email failures that are not "HTTP".

The constant `Channels::HTTP` has been replaced with `Channels::NETWORK`, but for backward compatibility, the constant value is still the string `"HTTP"` (so if someone has any processing in place, it will continue working), and the constant `Channels::HTTP` still exists, as deprecated.
