### PR TITLE
Fix infinite recursion in Exception handler in PHP 8.3.5+

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -1021,19 +1021,8 @@ class Configurator
     {
         $updater = $this->factory->logActionUpdater();
         $logSilenced = (bool) $this->config[self::CONF_SILENCED_ERRORS];
-        $controller = PhpErrorController::new($logSilenced, $updater);
-
-        $logExceptions and set_exception_handler([$controller, 'onException']);
-
-        if ($errorTypes <= 0) {
-            return;
-        }
-
-        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-        set_error_handler([$controller, 'onError'], $errorTypes);
-        if (PhpErrorController::typesMaskContainsFatals($errorTypes)) {
-            register_shutdown_function([$controller, 'onShutdown']);
-        }
+        $controller = PhpErrorController::new($errorTypes, $logExceptions, $logSilenced, $updater);
+        $controller->setup();
     }
 
     /**

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -44,9 +44,10 @@ class PhpErrorController
         | E_RECOVERABLE_ERROR
         | E_PARSE;
 
-    private bool $logSilencedErrors;
+    private bool $alreadySetup = false;
 
-    private LogActionUpdater $updater;
+    /** @var callable|null */
+    private $previousHandler = null;
 
     /**
      * @param int $errorTypes
@@ -88,19 +89,53 @@ class PhpErrorController
      * @param LogActionUpdater $updater
      * @return PhpErrorController
      */
-    public static function new(bool $logSilencedErrors, LogActionUpdater $updater): PhpErrorController
-    {
-        return new self($logSilencedErrors, $updater);
+    public static function new(
+        int $errorTypes,
+        bool $logExceptions,
+        bool $logSilencedErrors,
+        LogActionUpdater $updater
+    ): PhpErrorController {
+
+        return new self($errorTypes, $logExceptions, $logSilencedErrors, $updater);
     }
 
     /**
+     * @param int $errorTypes
+     * @param bool $logExceptions
      * @param bool $logSilencedErrors
      * @param LogActionUpdater $updater
      */
-    private function __construct(bool $logSilencedErrors, LogActionUpdater $updater)
+    private function __construct(
+        private readonly int $errorTypes,
+        private readonly bool $logExceptions,
+        private readonly bool $logSilencedErrors,
+        private readonly LogActionUpdater $updater
+    ) {
+    }
+
+    /**
+     * @return void
+     */
+    public function setup(): void
     {
-        $this->logSilencedErrors = $logSilencedErrors;
-        $this->updater = $updater;
+        if ($this->alreadySetup) {
+            throw new \Exception(__METHOD__ . ' can only be executed once.');
+        }
+        $this->alreadySetup = true;
+
+        if ($this->logExceptions) {
+            $this->previousHandler = set_exception_handler([$this, 'onException']);
+        }
+
+        if ($this->errorTypes <= 0) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+        set_error_handler([$this, 'onError'], $this->errorTypes);
+        if (self::typesMaskContainsFatals($this->errorTypes)) {
+            register_shutdown_function([$this, 'onShutdown']);
+        }
     }
 
     /**
@@ -137,8 +172,15 @@ class PhpErrorController
         // Log the PHP exception.
         $this->updater->update(static::factoryThrowableLog($throwable));
 
-        // after logging let's reset handler and throw the exception
-        restore_exception_handler();
+        // If there was a previous handler, let's call it manually.
+        // this make sure that we can throw the exception at the end after having completely
+        // reset the handler, obtaining a "transparent" result.
+        if ($this->previousHandler) {
+            ($this->previousHandler)($throwable);
+        }
+
+        // Reset to the default handler and throw, to be transparent
+        set_exception_handler(null);
         throw $throwable;
     }
 
@@ -172,28 +214,17 @@ class PhpErrorController
      */
     private function isSilencedError(): bool
     {
-        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+        // phpcs:disable WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting
+        // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
         $errorReporting = error_reporting();
-
-        /**
-         * Prior to PHP 8, calling error_reporting() inside a custom error handler would return
-         * 0 if the error was suppressed via @, but as of PHP 8.0.0, it returns a fixed value.
-         * We can say the error is silenced if `error_reporting()` above returns that value and
-         * if that value is different from what is set in ini.
-         * @see https://www.php.net/manual/en/language.operators.errorcontrol.php
-         */
-        /** @var positive-int $phpVersion */
-        $phpVersion = PHP_MAJOR_VERSION;
-        if ($phpVersion >= 8) {
-            if ($errorReporting !== self::PHP_8_SILENCED_ERROR_CODE) {
-                return false;
-            }
-
-            // If the fixed value returned by `error_reporting()` for silenced error is set in the
-            // config we can't really tell the error was suppressed.
-            return (int) ini_get('error_reporting') !== $errorReporting;
+        // phpcs:enable WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting
+        // phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+        if ($errorReporting !== self::PHP_8_SILENCED_ERROR_CODE) {
+            return false;
         }
 
-        return $errorReporting === 0;
+        // If the fixed value returned by `error_reporting()` for silenced error is set in the
+        // config we can't really tell the error was suppressed.
+        return (int) ini_get('error_reporting') !== $errorReporting;
     }
 }

--- a/src/PhpErrorController.php
+++ b/src/PhpErrorController.php
@@ -115,11 +115,12 @@ class PhpErrorController
 
     /**
      * @return void
+     * @private
      */
     public function setup(): void
     {
         if ($this->alreadySetup) {
-            throw new \Exception(__METHOD__ . ' can only be executed once.');
+            return;
         }
         $this->alreadySetup = true;
 

--- a/tests/unit/PhpErrorHandlerTest.php
+++ b/tests/unit/PhpErrorHandlerTest.php
@@ -42,8 +42,13 @@ class PhpErrorHandlerTest extends UnitTestCase
             }
         );
 
-        $controller = PhpErrorController::new(true, $updater);
-        $this->initializeErrorController($controller);
+        $controller = PhpErrorController::new(
+            errorTypes: E_ALL,
+            logExceptions: false,
+            logSilencedErrors: true,
+            updater: $updater
+        );
+        $controller->setup();
 
         @trigger_error('Meh!', E_USER_NOTICE);
     }
@@ -66,8 +71,13 @@ class PhpErrorHandlerTest extends UnitTestCase
             }
         );
 
-        $controller = PhpErrorController::new(true, $updater);
-        $this->initializeErrorController($controller);
+        $controller = PhpErrorController::new(
+            errorTypes: E_ALL,
+            logExceptions: false,
+            logSilencedErrors: true,
+            updater: $updater
+        );
+        $controller->setup();
 
         @trigger_error('Warning!', E_USER_WARNING);
     }
@@ -77,12 +87,17 @@ class PhpErrorHandlerTest extends UnitTestCase
      */
     public function testOnException(): void
     {
+        $message = 'Exception!';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($message);
+
         $updater = \Mockery::mock(LogActionUpdater::class);
         $updater->expects('update')->andReturnUsing(
-            static function (LogData $log): void {
+            static function (LogData $log) use ($message): void {
                 static::assertSame(Channels::PHP_ERROR, $log->channel());
                 static::assertSame(LogLevel::CRITICAL, $log->level());
-                static::assertSame('Exception!', $log->message());
+                static::assertSame($message, $log->message());
                 $context = $log->context();
                 static::assertArrayHasKey('line', $context);
                 static::assertArrayHasKey('trace', $context);
@@ -93,14 +108,16 @@ class PhpErrorHandlerTest extends UnitTestCase
             }
         );
 
-        $controller = PhpErrorController::new(true, $updater);
-        $this->initializeErrorController($controller);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Exception!');
+        $controller = PhpErrorController::new(
+            errorTypes: E_ALL,
+            logExceptions: true,
+            logSilencedErrors: false,
+            updater: $updater
+        );
+        $controller->setup();
 
         try {
-            throw new \RuntimeException('Exception!');
+            throw new \RuntimeException($message);
         } catch (\Throwable $throwable) {
             $controller->onException($throwable);
         }
@@ -114,24 +131,19 @@ class PhpErrorHandlerTest extends UnitTestCase
     {
         $updater = \Mockery::mock(LogActionUpdater::class);
         $updater->expects('update')->never();
-        $controller = PhpErrorController::new(false, $updater);
-        $this->initializeErrorController($controller);
+
+        $controller = PhpErrorController::new(
+            errorTypes: E_ALL,
+            logExceptions: false,
+            logSilencedErrors: false,
+            updater: $updater
+        );
+        $controller->setup();
 
         $test = static function (): void {
             trigger_error('Test', E_USER_WARNING);
         };
 
         @$test();
-    }
-
-    /**
-     * @param PhpErrorController $controller
-     * @return void
-     */
-    private function initializeErrorController(PhpErrorController $controller): void
-    {
-        register_shutdown_function([$controller, 'onShutdown']);
-        set_error_handler([$controller, 'onError']);
-        set_exception_handler([$controller, 'onException']);
     }
 }


### PR DESCRIPTION
See #81

`restore_exception_handler` does not work from inside an exception handler.

Even if it never worked, in PHP < 8.3.0, throwing from a handler results in the default handler being called.

From PHP >= 8.3.0 < 8.3.5, throwing from a handler results in the default previous handler to be called, if any, or the default handler if not.

From PHP >= 8.3.5, throwing from a handler results in the same handler being called repeatedly, causing an infinite loop.

To achieve uniform behavior, we call the previous handler manually if it exists, then call `set_exception_handler(null)` to force the default handler, and finally, we throw the exception.

This should ensure the same flow in all supported versions:

1. Log the exception
2. Execute the previous handler, if any
3. Re-throw the exception

To do that, we have to store the previous handler at the moment the exception handler is set, so this PR moves the controller setup inside the controller class itself, allowing us to save the last handler in a property of the controller.

All tests are green, but the problem is that PHPUnit replaces the exception handler, so it is impossible to test this via PHPUnit. We need some e2e or manual tests to confirm that this works.

However, the simplified version of the new Controller can be evaluated in 3v4l.org here: https://3v4l.org/JmVIZ, and it appears to work consistently across all PHP versions.

For comparison, the situation before this PR can be seen here: https://3v4l.org/TH800