### PR TITLE
Hardcode PHPMailer\SMTP values to avoid race conditions due to early …

### DIFF
--- a/src/HookListener/MailerListener.php
+++ b/src/HookListener/MailerListener.php
@@ -28,6 +28,7 @@ class MailerListener implements ActionListener
         int $errorLogLevel = LogLevel::ERROR,
         int $smtpDebugLevel = 2, // PHPMailer\SMTP::DEBUG_SERVER - hardcoded to avoid race conditions
     ) {
+
         $this->errorLogLevel = LogLevel::normalizeLevel($errorLogLevel) ?? LogLevel::ERROR;
 
         $this->smtpDebugLevel = min(

--- a/src/HookListener/MailerListener.php
+++ b/src/HookListener/MailerListener.php
@@ -22,16 +22,17 @@ class MailerListener implements ActionListener
     /**
      * @param int $errorLogLevel
      * @param int $smtpDebugLevel
+     * @see PHPMailer\SMTP
      */
     public function __construct(
         int $errorLogLevel = LogLevel::ERROR,
-        int $smtpDebugLevel = PHPMailer\SMTP::DEBUG_SERVER,
+        int $smtpDebugLevel = 2, // PHPMailer\SMTP::DEBUG_SERVER - hardcoded to avoid race conditions
     ) {
-
         $this->errorLogLevel = LogLevel::normalizeLevel($errorLogLevel) ?? LogLevel::ERROR;
+
         $this->smtpDebugLevel = min(
-            max(PHPMailer\SMTP::DEBUG_OFF, $smtpDebugLevel),
-            PHPMailer\SMTP::DEBUG_LOWLEVEL
+            max(0, $smtpDebugLevel), // 0 = PHPMailer\SMTP::DEBUG_OFF
+            4 // 4 = PHPMailer\SMTP::DEBUG_LOWLEVEL
         );
     }
 


### PR DESCRIPTION
Wonolog is usually initialized very early in the request and WordPress recently changed the way PHPMailer is loaded. This results in fatal errors when the PHPMailer constants are not yet available when Wonolog boots.

Therefore we hardcode the values, pointing to their origin.
No functional changes.