### PR TITLE
Improve HookLogFactory::fromString() 

### DIFF
--- a/src/HookLogFactory.php
+++ b/src/HookLogFactory.php
@@ -143,6 +143,18 @@ class HookLogFactory
         string $defaultChannel
     ): LogData {
 
+        if ((count($arguments) === 1) && is_array($arguments[0] ?? null)) {
+            if (
+                isset($arguments[0][LogData::LEVEL])
+                || is_string($arguments[0][LogData::CHANNEL] ?? null)
+                || is_array($arguments[0][LogData::CONTEXT] ?? null)
+            ) {
+                $arguments[0][LogData::MESSAGE] = $value;
+
+                return self::fromArray($arguments[0], [], $defaultLevel, $defaultChannel);
+            }
+        }
+
         $log = new Log($value, $defaultLevel, $defaultChannel, $arguments);
 
         return $this->maybeRaiseLevel($defaultLevel, $log);

--- a/tests/integration/AdvancedConfigTest.php
+++ b/tests/integration/AdvancedConfigTest.php
@@ -340,13 +340,13 @@ class AdvancedConfigTest extends IntegrationTestCase
 
             if (
                 !$matches
-                || strtoupper($channel) !== ($matches['channel'] ?? null)
-                || strtoupper($level) !== ($matches['level'] ?? null)
+                || strtoupper($channel) !== ($matches['channel'])
+                || strtoupper($level) !== ($matches['level'])
             ) {
                 continue;
             }
 
-            $more = $matches['more'] ?? '';
+            $more = $matches['more'];
             $extra = json_encode(['testClass' => __CLASS__], \JSON_THROW_ON_ERROR);
             if (!preg_match('~' . preg_quote($extra, '~') . '~', $more)) {
                 continue;
@@ -359,7 +359,7 @@ class AdvancedConfigTest extends IntegrationTestCase
                 }
             }
 
-            $logText = $matches['txt'] ?? '';
+            $logText = $matches['txt'];
             if (!preg_match('~' . preg_quote($message, '~') . '~', $logText)) {
                 continue;
             }

--- a/tests/unit/HookLogFactoryTest.php
+++ b/tests/unit/HookLogFactoryTest.php
@@ -10,8 +10,8 @@ use Inpsyde\Wonolog\Data\Debug;
 use Inpsyde\Wonolog\Data\Error;
 use Inpsyde\Wonolog\Data\LogData;
 use Inpsyde\Wonolog\HookLogFactory;
+use Inpsyde\Wonolog\LogLevel;
 use Inpsyde\Wonolog\Tests\UnitTestCase;
-use Psr\Log\LogLevel;
 
 class HookLogFactoryTest extends UnitTestCase
 {
@@ -71,18 +71,18 @@ class HookLogFactoryTest extends UnitTestCase
         $args = compact('first', 'second');
 
         $factory = HookLogFactory::new();
-        $logs = $factory->logsFromHookArguments($args, \Inpsyde\Wonolog\LogLevel::WARNING);
+        $logs = $factory->logsFromHookArguments($args, LogLevel::WARNING);
 
         static::assertCount(2, $logs);
 
         static::assertInstanceOf(LogData::class, $first);
-        static::assertSame(\Inpsyde\Wonolog\LogLevel::WARNING, $logs[0]->level());
+        static::assertSame(LogLevel::WARNING, $logs[0]->level());
         static::assertSame($logs[0]->message(), $first->message());
         static::assertSame($logs[0]->channel(), $first->channel());
         static::assertSame($logs[0]->context(), $first->context());
 
         static::assertInstanceOf(LogData::class, $second);
-        static::assertSame(\Inpsyde\Wonolog\LogLevel::ERROR, $logs[1]->level());
+        static::assertSame(LogLevel::ERROR, $logs[1]->level());
         static::assertSame($logs[1]->message(), $second->message());
         static::assertSame($logs[1]->channel(), $second->channel());
         static::assertSame($logs[1]->context(), $second->context());
@@ -109,6 +109,116 @@ class HookLogFactoryTest extends UnitTestCase
     /**
      * @test
      */
+    public function testLogsFromStringWithLevelAndChannelFromSecondArgAsArray(): void
+    {
+        $logs = HookLogFactory::new()->logsFromHookArguments(
+            [
+                'Foo!',
+                [
+                    'level' => \Psr\Log\LogLevel::ALERT,
+                    'channel' => Channels::NETWORK,
+                    'x' => 'y',
+                    'foo',
+                ],
+            ]
+        );
+
+        static::assertCount(1, $logs);
+
+        /** @var LogData $log */
+        $log = reset($logs);
+
+        static::assertInstanceOf(LogData::class, $log);
+        static::assertSame('Foo!', $log->message());
+        static::assertSame(Channels::NETWORK, $log->channel());
+        static::assertSame(LogLevel::ALERT, $log->level());
+        static::assertSame([], $log->context());
+    }
+
+    /**
+     * @test
+     */
+    public function testLogsFromStringWithContextAndChannelFromSecondArgAsArray(): void
+    {
+        $logs = HookLogFactory::new()->logsFromHookArguments(
+            [
+                'Foo!',
+                [
+                    'channel' => Channels::NETWORK,
+                    'context' => ['Hello', 'World'],
+                    'x' => 'y',
+                    'foo',
+                ],
+            ]
+        );
+
+        static::assertCount(1, $logs);
+
+        /** @var LogData $log */
+        $log = reset($logs);
+
+        static::assertInstanceOf(LogData::class, $log);
+        static::assertSame($log->message(), 'Foo!');
+        static::assertSame($log->channel(), Channels::NETWORK);
+        static::assertSame($log->context(), ['Hello', 'World']);
+    }
+
+    /**
+     * @test
+     */
+    public function testLogsFromStringSecondArgAsArrayWithMoreArguments(): void
+    {
+        $logs = HookLogFactory::new()->logsFromHookArguments(
+            [
+                'Foo!',
+                ['channel' => Channels::NETWORK],
+                'bar',
+                ['X', 'Y'],
+            ]
+        );
+
+        static::assertCount(1, $logs);
+
+        /** @var LogData $log */
+        $log = reset($logs);
+
+        static::assertInstanceOf(LogData::class, $log);
+        static::assertSame($log->message(), 'Foo!');
+        static::assertSame($log->channel(), Channels::DEBUG);
+        static::assertSame($log->level(), LogLevel::DEBUG);
+        static::assertSame(
+            $log->context(),
+            [['channel' => Channels::NETWORK], 'bar', ['X', 'Y']]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testLogsFromStringSecondArgAsArrayIgnoredWhenNoTargetKeys(): void
+    {
+        $logs = HookLogFactory::new()->logsFromHookArguments(
+            [
+                'Foo!',
+                [Channels::NETWORK, LogLevel::ALERT],
+            ]
+        );
+
+        static::assertCount(1, $logs);
+
+        /** @var LogData $log */
+        $log = reset($logs);
+
+        static::assertInstanceOf(LogData::class, $log);
+        static::assertSame($log->message(), 'Foo!');
+        static::assertSame($log->channel(), Channels::DEBUG);
+        static::assertSame($log->level(), LogLevel::DEBUG);
+        static::assertSame($log->context(), [[Channels::NETWORK, LogLevel::ALERT]]);
+    }
+
+    /**
+     * @test
+     */
     public function testLogsFromWpError(): void
     {
         $error = \Mockery::mock(\WP_Error::class);
@@ -126,7 +236,7 @@ class HookLogFactoryTest extends UnitTestCase
 
         static::assertInstanceOf(LogData::class, $log);
         static::assertSame($log->message(), 'Foo!');
-        static::assertSame($log->level(), \Inpsyde\Wonolog\LogLevel::NOTICE);
+        static::assertSame($log->level(), LogLevel::NOTICE);
         static::assertSame($log->channel(), Channels::DB);
         static::assertSame($log->context(), ['db broken']);
     }
@@ -154,7 +264,7 @@ class HookLogFactoryTest extends UnitTestCase
 
         static::assertInstanceOf(LogData::class, $log);
         static::assertSame('Error!', $log->message());
-        static::assertSame(\Inpsyde\Wonolog\LogLevel::ERROR, $log->level());
+        static::assertSame(LogLevel::ERROR, $log->level());
         static::assertSame(Channels::SECURITY, $log->channel());
         static::assertSame(['some', 'data'], $log->context());
     }
@@ -176,7 +286,7 @@ class HookLogFactoryTest extends UnitTestCase
 
         static::assertInstanceOf(LogData::class, $log);
         static::assertSame($log->message(), 'Foo!');
-        static::assertSame($log->level(), \Inpsyde\Wonolog\LogLevel::ERROR);
+        static::assertSame($log->level(), LogLevel::ERROR);
         static::assertSame($log->channel(), Channels::DEBUG);
     }
 
@@ -187,16 +297,13 @@ class HookLogFactoryTest extends UnitTestCase
     {
         $data = [
             'message' => 'Hello!',
-            'level' => \Inpsyde\Wonolog\LogLevel::NOTICE,
+            'level' => LogLevel::NOTICE,
             'channel' => Channels::SECURITY,
             'context' => ['foo', 'bar'],
         ];
 
         $factory = HookLogFactory::new();
-        $logs = $factory->logsFromHookArguments(
-            [$data, 'x', 'y'],
-            \Inpsyde\Wonolog\LogLevel::DEBUG
-        );
+        $logs = $factory->logsFromHookArguments([$data, 'x', 'y'], LogLevel::DEBUG);
 
         static::assertCount(1, $logs);
 
@@ -205,7 +312,7 @@ class HookLogFactoryTest extends UnitTestCase
 
         static::assertInstanceOf(LogData::class, $log);
         static::assertSame($log->message(), 'Hello!');
-        static::assertSame($log->level(), \Inpsyde\Wonolog\LogLevel::NOTICE);
+        static::assertSame($log->level(), LogLevel::NOTICE);
         static::assertSame($log->channel(), Channels::SECURITY);
     }
 
@@ -216,16 +323,13 @@ class HookLogFactoryTest extends UnitTestCase
     {
         $data = [
             'message' => 'Hello!',
-            'level' => \Inpsyde\Wonolog\LogLevel::DEBUG,
+            'level' => LogLevel::DEBUG,
             'channel' => Channels::SECURITY,
             'context' => ['foo', 'bar'],
         ];
 
         $factory = HookLogFactory::new();
-        $logs = $factory->logsFromHookArguments(
-            [$data, 600, 'y'],
-            \Inpsyde\Wonolog\LogLevel::NOTICE
-        );
+        $logs = $factory->logsFromHookArguments([$data, 600, 'y'], LogLevel::NOTICE);
 
         static::assertCount(1, $logs);
 
@@ -234,7 +338,7 @@ class HookLogFactoryTest extends UnitTestCase
 
         static::assertInstanceOf(LogData::class, $log);
         static::assertSame($log->message(), 'Hello!');
-        static::assertSame($log->level(), \Inpsyde\Wonolog\LogLevel::NOTICE);
+        static::assertSame($log->level(), LogLevel::NOTICE);
         static::assertSame($log->channel(), Channels::SECURITY);
     }
 


### PR DESCRIPTION
# The issue

The documentation [states](https://inpsyde.github.io/Wonolog/04-designing-packages-for-wonolog/#about-log-channel) that when the log record's “context” array has a key "channel", Wonolog uses that context value as the log record channel.

This is true when an action hook uses only one argument as array, for example:

```php
do_action('wonolog.log', ['message' => 'My message', 'channel' => '...']);
```

but it is _not_ true when passing the message as first argument as string:


```php
do_action('wonolog.log', 'My message', ['channel' => '...']);
```

Reported via #123 

# The cause

The problem is that the source for "channel" (but also "level") when creating a log entry from a hook's arguments is the _first_ argument passed to the hook.

# The solution

Iit makes sense that when exactly 2 arguments are passed, and the second argument is an array containing relevant info, we use that info. So, the two snippets above are equivalent.

However, when multiple arguments are passed, or when the second argument is an array that does not contain relevant info ("level", "channel", "context") nothing changes, keeping backward compatibility.

This PR addresses this, adding unit tests.

---

Note: a second commit in this PR addresses some PHPStan errors in a n unrelated test file (`AdvancedConfigTest.php`) so that the CI could be green, facilitating the merge.