### PR TITLE
Correctly skip HTTP status code check for non-blocking requests

### DIFF
--- a/src/HookListener/HttpApiListener.php
+++ b/src/HookListener/HttpApiListener.php
@@ -115,15 +115,16 @@ final class HttpApiListener implements ActionListener
      */
     private function isError(array $response, array $httpArgs = []): bool
     {
+        if (array_key_exists('blocking', $httpArgs) && !$httpArgs['blocking']) {
+            // If the request is non-blocking, we cannot determine if it was an error or not.
+            return false;
+        }
+
         $responseData = $response['response'] ?? null;
         $code = is_array($responseData) ? ($responseData['code'] ?? null) : null;
 
         if (!$code || !is_numeric($code)) {
             return true;
-        }
-
-        if (array_key_exists('blocking', $httpArgs) && !$httpArgs['blocking']) {
-            return false;
         }
 
         return !in_array((int) $code, self::HTTP_SUCCESS_CODES, true);


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #127.

#### What's Included in This Pull Request

Stops incorrect HTTP errors occurring for non-blocking requests, where we don't have access to the status code.

To sense-check this, I used `wp shell` and ran the following:
```
add_action('http_api_debug', function($a, $b, $c, $d) {print_r($d);}, 10, 4);
wp_remote_get('https://example.com', ['blocking' => false]);
```

Despite the request completing, you will see that the status code is empty in the `print_r`'d response. That makes sense, as if the request is non-blocking, WordPress won't wait to receive a HTTP response code.

This re-orders the code, so that the blocking check actually gets reached; previously the `if (!$code || !is_numeric($code))` check was always returning `true` for blocking requests. 